### PR TITLE
UHF-1416: Disable user creation from anyone else except admin

### DIFF
--- a/conf/cmi/user.settings.yml
+++ b/conf/cmi/user.settings.yml
@@ -9,7 +9,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true


### PR DESCRIPTION
To test:

1. `make drush-cim drush-cr`
2. Log out if you are logged in and make sure you can't register as a user.

Test also:
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/3
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/81