### PR TITLE
UHF-910: Add Kuura Health Chat bot visible on all pages

### DIFF
--- a/conf/cmi/block.block.kuurahealthchat.yml
+++ b/conf/cmi/block.block.kuurahealthchat.yml
@@ -1,0 +1,20 @@
+uuid: 08de169f-07e2-4e32-ab63-9d44d39964cf
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_platform_config
+  theme:
+    - hdbt
+id: kuurahealthchat
+theme: hdbt
+region: attachments
+weight: -9
+provider: null
+plugin: kuura_health_chat
+settings:
+  id: kuura_health_chat
+  label: 'Kuura Health Chat'
+  provider: helfi_platform_config
+  label_display: '0'
+visibility: {  }


### PR DESCRIPTION
To test this feature on sote change to feature branches:
- `composer require drupal/hdbt:dev-UHF-910-kuura-chat-bot && composer require drupal/helfi_platform_config:dev-UHF-910-kuura-chat-bot`
- Run `make drush-cim`
- Run `make drush-cr`
- Go to any page on the public site (not admin side) and you should have Kuura Health Chat available on the bottom right corner.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/106
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/112