### PR TITLE
UHF-1775 Footer settings to config ignore

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -14359,5 +14359,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,4 +1,5 @@
 ignored_config_entities:
   - 'eu_cookie_compliance.cookie_category*'
+  - '*.site_settings'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/cmi/filter.format.full_html.yml
+++ b/conf/cmi/filter.format.full_html.yml
@@ -48,22 +48,6 @@ filters:
     weight: -48
     settings:
       title: true
-  token_filter:
-    id: token_filter
-    provider: token_filter
-    status: true
-    weight: -47
-    settings:
-      replace_empty: '1'
-  media_embed:
-    id: media_embed
-    provider: media
-    status: false
-    weight: -39
-    settings:
-      default_view_mode: default
-      allowed_media_types: {  }
-      allowed_view_modes: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
@@ -94,3 +78,19 @@ filters:
     status: false
     weight: -40
     settings: {  }
+  media_embed:
+    id: media_embed
+    provider: media
+    status: false
+    weight: -39
+    settings:
+      default_view_mode: default
+      allowed_media_types: {  }
+      allowed_view_modes: {  }
+  token_filter:
+    id: token_filter
+    provider: token_filter
+    status: true
+    weight: -47
+    settings:
+      replace_empty: '1'

--- a/conf/cmi/hdbt_admin_tools.site_settings.yml
+++ b/conf/cmi/hdbt_admin_tools.site_settings.yml
@@ -1,13 +1,13 @@
 langcode: en
 site_settings:
-  theme_color: bus
+  theme_color: coat-of-arms
   default_icon: group
   koro: pulse
 footer_settings:
   footer_color: dark
   footer_top_title: 'Contact information'
   footer_top_content:
-    value: "<p><a href=\"#\">Search for contacts and phone numbers</a></p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary\" href=\"#\"><span class=\"hds-button__label\">Helsinki-info 09 310 1691</span></a></p>\r\n"
+    value: "<p><a href=\"#\">Search for contacts and phone numbers</a></p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary hdbt-icon hdbt-icon--phone\" data-design=\"hds-button hds-button--secondary\" data-icon=\"phone\" data-link-text=\"Helsinki-info 09 310 1691\" data-protocol=\"false\" href=\"#\"><span class=\"hds-button__label\">Helsinki-info 09 310 1691</span></a></p>\r\n"
     format: full_html
 _core:
   default_config_hash: AOXdYmkvKEWQ90i8bbStpi07jONjN29ny1BcgITQFSM

--- a/conf/cmi/language/fi/hdbt_admin_tools.site_settings.yml
+++ b/conf/cmi/language/fi/hdbt_admin_tools.site_settings.yml
@@ -1,5 +1,5 @@
 footer_settings:
   footer_top_content:
+    value: "<p><a href=\"#\">Hae yhteystietoja ja numeroita</a></p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary hdbt-icon hdbt-icon--phone\" data-design=\"hds-button hds-button--secondary\" data-icon=\"phone\" data-link-text=\"Helsinki-info 09 310 1691\" data-protocol=\"false\" href=\"#\"><span class=\"hds-button__label\">Helsinki-info 09 310 1691</span></a></p>\r\n"
     format: full_html
-    value: '<p><a href="#">Hae yhteystietoja ja numeroita</a></p><p><a href="#" class="hds-button hds-button--secondary"><span aria-hidden="true" class="hds-icon hds-icon--phone"></span><span class="hds-button__label">Helsinki-info 09 310 1691</span></a></p>'
   footer_top_title: Yhteystiedot


### PR DESCRIPTION
To test assuming you have a site running on your local:

1. Change into this branch: `git checkout UHF-1775-footer-settings-to-config-ignore`
2. Import configuration changes: `make drush-cim`
3. Clear caches: `make drush-cr`
4. Go to https://helfi-sote.docker.so/fi/admin/tools/site-settings and change a setting (for example write something new to the footer) and save the settings. Make sure the change you did to your footer is visible on the site (make sure you are viewing the site with the language that you made the change to.
5. Run `make drush-cim`
6. The configuration import shouldn't revert your changes and it should say that there is nothing to import.
7. Notice: if you EXPORT the changes that you made using `make drush-cex` they will still be exported and this is fine but naturally don't export any new changes to this PR :)

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi/pull/150
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/31
https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/120