### PR TITLE
UHF-2303: Navigation block level change

### DIFF
--- a/conf/cmi/block.block.main_navigation_level_2.yml
+++ b/conf/cmi/block.block.main_navigation_level_2.yml
@@ -26,7 +26,7 @@ settings:
     views: views
     menu_link_content: menu_link_content
     default: '0'
-  level: 2
+  level: 3
   depth: 0
   expand_all_items: true
 visibility:

--- a/conf/cmi/block.block.mainnavigation.yml
+++ b/conf/cmi/block.block.mainnavigation.yml
@@ -25,7 +25,7 @@ settings:
     views: views
     menu_link_content: menu_link_content
     default: '0'
-  level: 3
+  level: 2
   depth: 2
   expand_all_items: true
 visibility: {  }

--- a/conf/cmi/block.block.mainnavigation.yml
+++ b/conf/cmi/block.block.mainnavigation.yml
@@ -25,7 +25,7 @@ settings:
     views: views
     menu_link_content: menu_link_content
     default: '0'
-  level: 1
+  level: 3
   depth: 2
   expand_all_items: true
 visibility: {  }


### PR DESCRIPTION
How to test:

1. Checkout this branch: `git fetch && git checkout UHF-2303_navigation_block_level_change`
2. Run `make drush-cim && make drush-cr`
3. Go to the site and make sure your main menu structure is similar to what the real menu tree will be like but no need to copy the whole tree:
Terveydenhoito (<front>)
----> Terveysasemat (landing page)
---->----> Idän terveysasema/Vuosaari (tpr unit)
---->----> Lännen terveysasema/Kannelmäki (tpr unit)
---->----> etc. 
4. Go to Terveysasemat landing page and you should see on the main menu the "Idän terveysasema/Vuosaari" and "Lännen terveysasema/Kannelmäki" unit pages.
5. Go to either of the unit pages and the menu on the left should make sense as well.