### PR TITLE
UHF-405: 'Provided languages' field value displayed in TPR unit

### DIFF
--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -168,6 +168,14 @@ content:
       view_mode: image
       link: false
     third_party_settings: {  }
+  provided_languages:
+    type: string
+    weight: 21
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
   service_map_embed:
     label: hidden
     type: service_map_embed


### PR DESCRIPTION
How to test:

- Set up SOTE site using this branch
- See that the "Provided languages" field is visible in "TPR Unit" field settings

NOTE: this PR relies on https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/49

TODO: add to other sites & display modes?