### PR TITLE
UHF-X: Change the Swedish and English site names to match urls

### DIFF
--- a/conf/cmi/language/sv/system.site.yml
+++ b/conf/cmi/language/sv/system.site.yml
@@ -1,1 +1,1 @@
-name: 'Social- och hälsovård'
+name: 'Social- och hälsovårdstjänster'

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -1,5 +1,5 @@
 uuid: 60950f0a-3a1f-44b8-9480-e0a4df36cfa5
-name: 'Social services and health care'
+name: 'Health and social services'
 mail: drupal@hel.fi
 slogan: ''
 page:


### PR DESCRIPTION
How to test:

1. Checkout this branch on sote instance
2. Run `make drush-cim && make drush-cr`
3. Go to the site front page and make sure that on Swedish language version the site name is Social- och hälsovårdstjänster and on English version Health and social services.