### PR TITLE
UHF-2838: fixed service path translations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4257,16 +4257,16 @@
         },
         {
             "name": "drupal/helfi_tpr",
-            "version": "1.4.5",
+            "version": "1.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr.git",
-                "reference": "57e63e7eabe0dc6ae1f07a87165050058146d6dd"
+                "reference": "54feebeaff443a90a5abb78680d9f914d9871e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/57e63e7eabe0dc6ae1f07a87165050058146d6dd",
-                "reference": "57e63e7eabe0dc6ae1f07a87165050058146d6dd",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/54feebeaff443a90a5abb78680d9f914d9871e65",
+                "reference": "54feebeaff443a90a5abb78680d9f914d9871e65",
                 "shasum": ""
             },
             "require": {
@@ -4287,10 +4287,10 @@
             ],
             "description": "TPR integration",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/1.4.5",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/1.4.6",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/issues"
             },
-            "time": "2021-10-12T06:27:16+00:00"
+            "time": "2021-10-14T06:56:33+00:00"
         },
         {
             "name": "drupal/helfi_tunnistamo",
@@ -16525,5 +16525,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Tpr module update which contains the fix to service entity path translations & bulk updating the paths

To test, check [UHF-2838 PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/64)