### PR TITLE
UHF-2828: Siteimprove config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4126,16 +4126,16 @@
         },
         {
             "name": "drupal/helfi_platform_config",
-            "version": "2.0.17",
+            "version": "2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config.git",
-                "reference": "81d53790da4dcd7f29adf72f1fd9f28019b97f47"
+                "reference": "cfdd1eb0bed0af4c64cf572543686ed139cc6e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/81d53790da4dcd7f29adf72f1fd9f28019b97f47",
-                "reference": "81d53790da4dcd7f29adf72f1fd9f28019b97f47",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-helfi-platform-config/zipball/cfdd1eb0bed0af4c64cf572543686ed139cc6e49",
+                "reference": "cfdd1eb0bed0af4c64cf572543686ed139cc6e49",
                 "shasum": ""
             },
             "require": {
@@ -4215,10 +4215,10 @@
             ],
             "description": "HELfi platform config",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/latest",
+                "source": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/tree/2.0.18",
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
-            "time": "2021-10-14T14:53:48+00:00"
+            "time": "2021-10-18T06:01:11+00:00"
         },
         {
             "name": "drupal/helfi_proxy",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -53,6 +53,7 @@ module:
   helfi_media_map_config: 0
   helfi_platform_config: 0
   helfi_proxy: 0
+  helfi_siteimprove_config: 0
   helfi_tpr: 0
   helfi_tpr_config: 0
   helfi_tpr_unit_districts: 0
@@ -102,6 +103,7 @@ module:
   select2_icon: 0
   serialization: 0
   simple_sitemap: 0
+  siteimprove: 0
   social_media: 0
   syslog: 0
   system: 0

--- a/conf/cmi/siteimprove.domain.single.settings.yml
+++ b/conf/cmi/siteimprove.domain.single.settings.yml
@@ -1,0 +1,3 @@
+domain: ''
+_core:
+  default_config_hash: LwImylUTdzscxHfVmILtYqYn7gdXYdNMhWwzpzTwTbU

--- a/conf/cmi/siteimprove.settings.yml
+++ b/conf/cmi/siteimprove.settings.yml
@@ -1,0 +1,9 @@
+token: e398be18e27e42aaa2ee4c22e7e7e9fb
+_core:
+  default_config_hash: t5W6QbLZA8s7VAoHDDldhRB2Emm1blOGOOKHMV855Gk
+domain_plugin_id: siteimprovedomain_simple
+prepublish_enabled: false
+api_username: ''
+api_key: ''
+enabled_content_types: {  }
+enabled_taxonomies: {  }

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -148,3 +148,6 @@ permissions:
   - 'view tpr_service'
   - 'view tpr_unit'
   - 'view unpublished paragraphs'
+  - 'use siteimprove'
+  - 'administer siteimprove'
+  - 'use siteimprove prepublish'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -66,3 +66,5 @@ permissions:
   - 'create hel_map media'
   - 'delete own hel_map media'
   - 'edit own hel_map media'
+  - 'use siteimprove'
+  - 'use siteimprove prepublish'

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -48,6 +48,10 @@ if (isset($_SERVER['WODBY_APP_NAME'])) {
 
 $config['openid_connect.client.tunnistamo']['settings']['client_id'] = getenv('TUNNISTAMO_CLIENT_ID');
 $config['openid_connect.client.tunnistamo']['settings']['client_secret'] = getenv('TUNNISTAMO_CLIENT_SECRET');
+
+$config['siteimprove.settings']['api_username'] = getenv('SITEIMPROVE_API_USERNAME');
+$config['siteimprove.settings']['api_key'] = getenv('SITEIMPROVE_API_KEY');
+
 // Drupal route(s).
 $routes = (getenv('DRUPAL_ROUTES')) ? explode(',', getenv('DRUPAL_ROUTES')) : [];
 


### PR DESCRIPTION
How to test:

- Install SOTE instance
- Checkout this branch: `git checkout UHF-2828_siteimprove_config`
- Import config: `make drush-cim`
- Log in as admin and make sure that
  - `helfi_siteimprove_config` and `siteimprove` modules are enabled
  - Siteimprove module has configuration in place
  - Permissions for admin and content producer roles are as in their respective yml´s 