### PR TITLE
UHF-2533: Show Kuura Health Chat only with Finnish content

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_kuurahealthchat.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_kuurahealthchat.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - helfi_platform_config
+    - language
   theme:
     - hdbt_subtheme
 id: hdbt_subtheme_kuurahealthchat
@@ -17,4 +18,11 @@ settings:
   label: 'Kuura Health Chat'
   provider: helfi_platform_config
   label_display: '0'
-visibility: {  }
+visibility:
+  language:
+    id: language
+    langcodes:
+      fi: fi
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_content'


### PR DESCRIPTION
**How to test**

* Set up a local _sote_ environment.
* Checkout this branch and run e.g. `make fresh`.
* View some content (e.g. nodes and custom entities) and check that the Kuura Health Chat at the bottom right is only visible when viewing Finnish content.