### PR TITLE
UHF-2697: Components and containers

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/content/tpr-errand-service.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/tpr-errand-service.html.twig
@@ -5,21 +5,4 @@
  */
 #}
 
-{%
-  set classes = [
-  'errand-service',
-  view_mode ? 'errand-service--' ~ view_mode|clean_class,
-]
-%}
-
-<article{{ attributes.addClass(classes) }}>
-
-  <div class="errand-service__container container">
-    {% if content.channels|render %}
-      <div class="errand-service__channels">
-        {{ content.channels }}
-      </div>
-    {% endif %}
-  </div>
-
-</article>
+{% include '@hdbt/content/tpr-errand-service.html.twig' ignore missing with { errand_service_simple_mode: true } %}

--- a/public/themes/custom/hdbt_subtheme/templates/content/tpr-service.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/tpr-service.html.twig
@@ -5,22 +5,4 @@
  */
 #}
 
-{% if drupal_entity('block', 'hdbt_subtheme_main_navigation_level_2', check_access=false)|render|striptags|trim is not empty %}
-  {% set in_menu =  TRUE %}
-{% endif %}
-
-{% if content.field_sidebar_content|render|striptags|trim is not empty %}
-  {% set sidebar_content = TRUE %}
-{% endif %}
-
-{% embed '@helfi_tpr/tpr-service.html.twig' with {in_menu: in_menu, sidebar_content: sidebar_content} %}
-  {% block sidebar_block %}
-    {{ drupal_entity('block', 'hdbt_subtheme_main_navigation_level_2', check_access=false) }}
-    {{ content.field_sidebar_content }}
-  {% endblock sidebar_block %}
-  {% block main_content %}
-    <div class="enriched-content has-sidebar">
-      {{ content.field_content }}
-    </div>
-  {% endblock main_content %}
-{% endembed %}
+{% include '@hdbt/content/tpr-service.html.twig' ignore missing with { block_name: 'hdbt_subtheme_main_navigation_level_2' } %}

--- a/public/themes/custom/hdbt_subtheme/templates/content/tpr-unit.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/tpr-unit.html.twig
@@ -5,35 +5,4 @@
  */
 #}
 
-{% if drupal_entity('block', 'hdbt_subtheme_main_navigation_level_2', check_access=false)|render|striptags|trim is not empty %}
-  {% set in_menu =  TRUE %}
-{% endif %}
-
-{% embed '@helfi_tpr/tpr-unit.html.twig' with {in_menu: in_menu} %}
-  {% block sidebar_block %}
-    {{ drupal_entity('block', 'hdbt_subtheme_main_navigation_level_2', check_access=false) }}
-  {% endblock sidebar_block %}
-
-  {% block main_content %}
-    <div class="enriched-content has-sidebar">
-      {{ content.field_content }}
-    </div>
-  {% endblock main_content %}
-
-  {% block accessibility_sentences_block %}
-    {% if content.accessibility_sentences|render %}
-      <div class="unit__accessibility_sentences accordion accordion--grey">
-        {% embed "@hdbt/misc/container.twig" ignore missing with {container_element: 'accordion'} %}
-          {% block container_content %}
-            {% include '@hdbt/component/accordion.twig' ignore missing with {
-              heading_level: 'h2',
-              heading_icon: 'person-wheelchair',
-              heading: 'Accessibility information'|t,
-              content: content.accessibility_sentences,
-            } %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    {% endif %}
-  {% endblock accessibility_sentences_block %}
-{% endembed %}
+{% include '@hdbt/content/tpr-unit.html.twig' ignore missing with { block_name: 'hdbt_subtheme_main_navigation_level_2' } %}


### PR DESCRIPTION
UHF-2697: Fix subtheme templates to use hdbt templates with variables instead of code duplication

Related to to https://github.com/City-of-Helsinki/drupal-hdbt/pull/180