### PR TITLE
UHF-3071: Show Kuura chat only with specific paths

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_kuurahealthchat.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_kuurahealthchat.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - helfi_platform_config
     - language
+    - system
   theme:
     - hdbt_subtheme
 id: hdbt_subtheme_kuurahealthchat
@@ -26,3 +27,7 @@ visibility:
     negate: false
     context_mapping:
       language: '@language.current_language_context:language_content'
+  request_path:
+    id: request_path
+    pages: "/terveydenhoito/terveysasemat\r\n/terveydenhoito/terveysasemat/*"
+    negate: false


### PR DESCRIPTION
**How to test:**
* Start with local `sote` environment.
* Checkout this branch.
* Run e.g. `make fresh` (or `drush cim` and `drush cr`).
* Make sure that Kuura Health Chat is only visible with Finnish content with path prefixed with `/terveydenhoito/terveysasemat`. This should include:
  * The Health stations page: `/terveydenhoito/terveysasemat`
  * Individual health stations
  * Individual services with the same path prefix.
* Make sure that the chat is not visible on other pages, e.g. on a normal basic page.