### PR TITLE
UHF-3560: Fix Finnish term to correct one

### DIFF
--- a/conf/cmi/language/fi/helfi_proxy.settings.yml
+++ b/conf/cmi/language/fi/helfi_proxy.settings.yml
@@ -1,1 +1,1 @@
-front_page_title: 'Sosiaali- ja terveydenhuolto'
+front_page_title: 'Sosiaali- ja terveyspalvelut'


### PR DESCRIPTION
How to test:

1. `make drush-cim && make drush-cr`
2. Check that the Finnish translation on the breadcrumb is the correct Sosiaali- ja terveyspalvelut