### PR TITLE
UHF-3552: Set service-channel heading level to h2

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-service-channel.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/module/helfi_tpr/tpr-service-channel.html.twig
@@ -1,0 +1,8 @@
+{#
+/**
+ * @file
+ * Template for a TPR Service Channel entity.
+ */
+#}
+
+{% embed "@hdbt/module/helfi_tpr/tpr-service-channel.html.twig" with {service_channel_heading_level: 'h2'} %}{% endembed %}


### PR DESCRIPTION
Please see: https://github.com/City-of-Helsinki/drupal-hdbt/pull/209

Related: [HDBT](https://github.com/City-of-Helsinki/drupal-hdbt/pull/209), [helfi_tpr](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/81/files)