### PR TITLE
UHF-3166: moved provided_languages functionality to a custom module

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4357,16 +4357,16 @@
         },
         {
             "name": "drupal/helfi_tpr",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr.git",
-                "reference": "bf6d435b5b0d887d263078ad70cc5fdfd3563b61"
+                "reference": "039bb5b49d0ff349472b4f010b49f7240b52f0df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/bf6d435b5b0d887d263078ad70cc5fdfd3563b61",
-                "reference": "bf6d435b5b0d887d263078ad70cc5fdfd3563b61",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-tpr/zipball/039bb5b49d0ff349472b4f010b49f7240b52f0df",
+                "reference": "039bb5b49d0ff349472b4f010b49f7240b52f0df",
                 "shasum": ""
             },
             "require": {
@@ -4388,10 +4388,10 @@
             ],
             "description": "TPR integration",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/2.0.5",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/tree/2.0.6",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/issues"
             },
-            "time": "2022-03-18T10:46:31+00:00"
+            "time": "2022-03-31T07:35:58+00:00"
         },
         {
             "name": "drupal/helfi_tunnistamo",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -60,6 +60,7 @@ module:
   helfi_platform_config: 0
   helfi_proxy: 0
   helfi_siteimprove_config: 0
+  helfi_sote: 0
   helfi_toc: 0
   helfi_tpr: 0
   helfi_tpr_config: 0

--- a/public/modules/custom/helfi_sote/helfi_sote.info.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.info.yml
@@ -4,4 +4,5 @@ type: module
 package: Custom
 core: 8.x
 core_version_requirement: ^8 || ^9
-
+dependencies:
+  - helfi_tpr:helfi_tpr

--- a/public/modules/custom/helfi_sote/helfi_sote.info.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.info.yml
@@ -1,0 +1,7 @@
+name: HELfi SOTE
+description: hel.fi SOTE specific funtionality
+type: module
+package: Custom
+core: 8.x
+core_version_requirement: ^8 || ^9
+

--- a/public/modules/custom/helfi_sote/helfi_sote.module
+++ b/public/modules/custom/helfi_sote/helfi_sote.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Contains helfi_sote.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_HOOK()
+ */
+function helfi_sote_preprocess_tpr_unit(array &$variables) {
+  // Get provided languages for the template.
+  $provided_languages = $variables['entity']->get('provided_languages')->getValue();
+
+  foreach ($provided_languages as $provided_language) {
+    $variables['provided_languages'][] = $provided_language['value'];
+  }
+}

--- a/public/modules/custom/helfi_sote/helfi_sote.module
+++ b/public/modules/custom/helfi_sote/helfi_sote.module
@@ -10,7 +10,7 @@ declare(strict_types=1);
 /**
  * Implements hook_preprocess_HOOK()
  */
-function helfi_sote_preprocess_tpr_unit(array &$variables) {
+function helfi_sote_preprocess_tpr_unit(array &$variables) : void {
   // Get provided languages for the template.
   $provided_languages = $variables['entity']->get('provided_languages')->getValue();
 


### PR DESCRIPTION
Moved `provided_languages` functionality from the `helfi_tpr` module to a SOTE specific custom module (see the `helfi_tpr` PR: https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/108)

How to test:
- install SOTE environment
- checkout this branch: `git checkout UHF-1179_swedish_service_sote`
- import config: `make drush-cim`
- get the equivalent branch of the `helfi_tpr` module: `composer require drupal/helfi_tpr:dev-UHF-1179_remove_swedish_service`
- clear cache: `make drush-cr`
- import some TPR units
- navigate to a TPR unit page that provides Swedish service and see that the label is there
- also create a unit search and see that the label is also visible on the unit cards listed there