### PR TITLE
UHF-5070: Enable default proxy domain

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -8,3 +8,9 @@
 if ($hotjar_id = getenv('HOTJAR_ID')) {
   $config['helfi_hotjar.settings']['hjid'] = $hotjar_id;
 }
+
+if ($drush_options_uri = getenv('DRUSH_OPTIONS_URI')) {
+  if (str_contains($drush_options_uri, 'www.hel.fi')) {
+    $config['helfi_proxy.settings']['default_proxy_domain'] = 'www.hel.fi';
+  }
+}


### PR DESCRIPTION
To test this:

- Add `$config['helfi_proxy.settings']['default_proxy_domain'] = 'helfi-proxy.docker.so';` to your `public/sites/default/local.settings.php` file
- Start local proxy for sote: `./start.sh sote`. See https://github.com/City-of-Helsinki/drupal-helfi-local-proxy for installation instructions

Make sure `helfi-sote.docker.so` domain always redirects to `helfi-proxy.docker.so`.