### PR TITLE
UHF-5444: Unit accessibility information paragraph

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.unit_accessibility_information.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.unit_accessibility_information.default.yml
@@ -1,0 +1,25 @@
+uuid: 140847ad-3c19-456e-8dfe-0f37ff312273
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.default
+targetEntityType: paragraph
+bundle: unit_accessibility_information
+mode: default
+content:
+  field_unit_accessibility_unit:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/conf/cmi/core.entity_view_display.paragraph.unit_accessibility_information.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.unit_accessibility_information.default.yml
@@ -1,0 +1,21 @@
+uuid: 1a64b36e-f038-4576-8916-cee3785eafd1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.default
+targetEntityType: paragraph
+bundle: unit_accessibility_information
+mode: default
+content:
+  field_unit_accessibility_unit:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/conf/cmi/field.field.node.landing_page.field_content.yml
+++ b/conf/cmi/field.field.node.landing_page.field_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_content
     - node.type.landing_page
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.content_cards
     - paragraphs.paragraphs_type.content_liftup
@@ -15,6 +16,7 @@ dependencies:
     - paragraphs.paragraphs_type.map
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.service_list
+    - paragraphs.paragraphs_type.unit_accessibility_information
     - paragraphs.paragraphs_type.unit_search
   module:
     - entity_reference_revisions
@@ -43,9 +45,10 @@ settings:
       from_library: from_library
       remote_video: remote_video
       map: map
+      chart: chart
       unit_search: unit_search
       service_list: service_list
-      chart: chart
+      unit_accessibility_information: unit_accessibility_information
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -63,6 +66,12 @@ settings:
       columns:
         weight: -37
         enabled: true
+      contact_card:
+        weight: 31
+        enabled: false
+      contact_card_listing:
+        weight: 32
+        enabled: false
       content_cards:
         weight: -33
         enabled: true
@@ -102,9 +111,18 @@ settings:
       service_list:
         weight: 36
         enabled: true
+      sidebar_text:
+        weight: 46
+        enabled: false
+      social_media_link:
+        weight: 47
+        enabled: false
       text:
         weight: -24
         enabled: false
+      unit_accessibility_information:
+        weight: 49
+        enabled: true
       unit_search:
         weight: 28
         enabled: true

--- a/conf/cmi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
+++ b/conf/cmi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
@@ -1,0 +1,26 @@
+uuid: f4f631fd-f821-4c66-8575-e05268d035d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.field_unit_accessibility_unit
+field_name: field_unit_accessibility_unit
+entity_type: paragraph
+bundle: unit_accessibility_information
+label: Unit
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:tpr_unit'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: name
+      direction: DESC
+    auto_create: false
+field_type: entity_reference

--- a/conf/cmi/field.storage.paragraph.field_unit_accessibility_unit.yml
+++ b/conf/cmi/field.storage.paragraph.field_unit_accessibility_unit.yml
@@ -1,0 +1,20 @@
+uuid: 8f69e703-dba6-4098-824d-3dfd2614edd0
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - paragraphs
+id: paragraph.field_unit_accessibility_unit
+field_name: field_unit_accessibility_unit
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: tpr_unit
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
@@ -1,0 +1,1 @@
+label: Toimipiste

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.unit_accessibility_information.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.unit_accessibility_information.yml
@@ -1,0 +1,1 @@
+label: 'Toimipisteen esteettömyystiedot'

--- a/conf/cmi/paragraphs.paragraphs_type.unit_accessibility_information.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.unit_accessibility_information.yml
@@ -1,0 +1,10 @@
+uuid: 3c924e2b-01a4-4e8a-a5bc-53474f6a30e1
+langcode: en
+status: true
+dependencies: {  }
+id: unit_accessibility_information
+label: 'Unit accessibility information'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -5,6 +5,9 @@
  * Functions to support theming in the HDBT Subtheme.
  */
 
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\helfi_tpr\Entity\Unit;
+
 /**
  * Implements hook_preprocess_HOOK().
  */
@@ -15,7 +18,7 @@ function hdbt_subtheme_preprocess_block(&$variables) {
 }
 
 /**
- * Implements hook_theme_suggestions_HOOK_alter for blocks.
+ * Implements hook_theme_suggestions_HOOK_alter().
  */
 function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions) {
   // Load theme suggestions for blocks from parent theme.
@@ -53,6 +56,41 @@ function hdbt_subtheme_theme_suggestions_menu_alter(&$suggestions, $variables) {
       default:
         $suggestions[] = 'menu__' . $variables['attributes']['block_id'];
         break;
+    }
+  }
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An array of elements to display in view mode.
+ *   - paragraph: The paragraph object.
+ *   - view_mode: View mode; e.g., 'full', 'teaser'...
+ */
+function hdbt_subtheme_preprocess_paragraph(array &$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+  $paragraph_type = $paragraph->getType();
+
+  // Check if the paragraph is a type of unit accessibility information and
+  // get the information from the unit entity.
+  if ($paragraph_type == 'unit_accessibility_information') {
+    $langcode = \Drupal::languageManager()
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+    $unit = $paragraph->get('field_unit_accessibility_unit')
+      ?->first()
+      ?->get('entity')
+      ?->getTarget()
+      ?->getEntity();
+
+    if ($unit instanceof Unit && $unit->hasTranslation($langcode)) {
+
+      $variables['unit_accessbility_information'] = $unit
+        ->getTranslation($langcode)
+        ?->get('accessibility_sentences')
+        ?->view('full');
     }
   }
 }

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--unit-accessibility-information.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--unit-accessibility-information.html.twig
@@ -1,0 +1,34 @@
+{% if unit_accessbility_information|render %}
+  {% embed "@hdbt/misc/component.twig" with
+    {
+      component_classes: [
+      'component--accordion',
+      'component--accordion-bg-grey',
+      'component--hardcoded',
+      'component--tpr-unit',
+    ],
+      component_content_class: 'accordion',
+    }
+  %}
+    {% block component_content %}
+
+      {% set accordion_content %}
+
+        {% embed "@hdbt/misc/component.twig" with { component_classes: [ 'component--paragraph-text' ] } %}
+          {% block component_content %}
+            {{ unit_accessbility_information }}
+          {% endblock component_content %}
+        {% endembed %}
+
+      {% endset %}
+
+      {% include '@hdbt/component/accordion.twig' ignore missing with {
+        heading_level: 'h2',
+        heading_icon: 'person-wheelchair',
+        heading: 'Accessibility information'|t,
+        content: accordion_content,
+      } %}
+
+    {% endblock component_content %}
+  {% endembed %}
+{% endif %}


### PR DESCRIPTION
# Unit accessibility information paragraph [UHF-5444](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5444)
Create a new paragraph called Unit accessibility information paragraph that can be added to SOTE landing pages.

## What was done
* Create a new paragraph called Unit accessibility information paragraph that can be added to SOTE landing pages.

## How to install
* Checkout this branch on your local setup.
* Run `make drush-cr && make drush-cim && make drush-cr`

## How to test
* You should now be able to add Unit accessibility information paragraph to any landing page. You need to provide only the unit which accessibility information you want to be displayed to the paragraph. Save the node and check that the correct information is shown. Make sure also the translations work.
