### PR TITLE
UHF-5844 Added missing configuration for phasing paragraph

### DIFF
--- a/conf/cmi/field.field.node.landing_page.field_content.yml
+++ b/conf/cmi/field.field.node.landing_page.field_content.yml
@@ -15,6 +15,7 @@ dependencies:
     - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.service_list
     - paragraphs.paragraphs_type.unit_accessibility_information
@@ -52,6 +53,7 @@ settings:
       event_list: event_list
       unit_contact_card: unit_contact_card
       service_list: service_list
+      phasing: phasing
       unit_accessibility_information: unit_accessibility_information
     negate: 0
     target_bundles_drag_drop:
@@ -112,6 +114,12 @@ settings:
       map:
         weight: -20
         enabled: true
+      phasing:
+        weight: 49
+        enabled: true
+      phasing_item:
+        weight: 50
+        enabled: false
       remote_video:
         weight: -22
         enabled: true

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -7,14 +7,17 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.contact_card_listing
     - paragraphs.paragraphs_type.content_cards
     - paragraphs.paragraphs_type.content_liftup
+    - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
-    - paragraphs.paragraphs_type.gallery
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
     - paragraphs.paragraphs_type.unit_accessibility_information
@@ -47,12 +50,13 @@ settings:
       banner: banner
       from_library: from_library
       content_liftup: content_liftup
+      chart: chart
       remote_video: remote_video
       unit_search: unit_search
-      map: map
-      chart: chart
-      contact_card_listing: contact_card_listing
       event_list: event_list
+      contact_card_listing: contact_card_listing
+      map: map
+      phasing: phasing
       unit_accessibility_information: unit_accessibility_information
       unit_contact_card: unit_contact_card
     negate: 0
@@ -114,9 +118,21 @@ settings:
       map:
         weight: 31
         enabled: true
+      phasing:
+        weight: 49
+        enabled: true
+      phasing_item:
+        weight: 50
+        enabled: false
       remote_video:
         weight: 27
         enabled: true
+      service_list:
+        weight: 52
+        enabled: false
+      sidebar_text:
+        weight: 53
+        enabled: false
       social_media_link:
         weight: 46
         enabled: false

--- a/conf/cmi/field.field.node.page.field_lower_content.yml
+++ b/conf/cmi/field.field.node.page.field_lower_content.yml
@@ -7,14 +7,17 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.contact_card_listing
     - paragraphs.paragraphs_type.content_cards
     - paragraphs.paragraphs_type.content_liftup
+    - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
-    - paragraphs.paragraphs_type.gallery
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.map
+    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
     - paragraphs.paragraphs_type.unit_accessibility_information
@@ -46,12 +49,13 @@ settings:
       unit_search: unit_search
       from_library: from_library
       content_liftup: content_liftup
+      chart: chart
+      event_list: event_list
+      contact_card_listing: contact_card_listing
       map: map
       remote_video: remote_video
-      chart: chart
-      contact_card_listing: contact_card_listing
       unit_contact_card: unit_contact_card
-      event_list: event_list
+      phasing: phasing
       unit_accessibility_information: unit_accessibility_information
     negate: 0
     target_bundles_drag_drop:
@@ -112,9 +116,21 @@ settings:
       map:
         weight: 31
         enabled: true
+      phasing:
+        weight: 49
+        enabled: true
+      phasing_item:
+        weight: 50
+        enabled: false
       remote_video:
         weight: 32
         enabled: true
+      service_list:
+        weight: 52
+        enabled: false
+      sidebar_text:
+        weight: 53
+        enabled: false
       social_media_link:
         weight: 46
         enabled: false

--- a/conf/cmi/field.field.paragraph.accordion_item.field_accordion_item_content.yml
+++ b/conf/cmi/field.field.paragraph.accordion_item.field_accordion_item_content.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.storage.paragraph.field_accordion_item_content
     - paragraphs.paragraphs_type.accordion_item
     - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.text
   module:
     - entity_reference_revisions
@@ -26,8 +28,9 @@ settings:
   handler_settings:
     target_bundles:
       columns: columns
-      text: text
       image: image
+      text: text
+      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -39,14 +42,26 @@ settings:
       banner:
         weight: 23
         enabled: false
+      chart:
+        weight: 33
+        enabled: false
       columns:
         weight: 14
         enabled: true
+      contact_card:
+        weight: 35
+        enabled: false
+      contact_card_listing:
+        weight: 36
+        enabled: false
       content_cards:
         weight: 25
         enabled: false
       content_liftup:
         weight: 26
+        enabled: false
+      event_list:
+        weight: 39
         enabled: false
       from_library:
         weight: 27
@@ -66,7 +81,6 @@ settings:
       liftup_with_image:
         weight: 32
         enabled: false
-      link: {  }
       list_of_links:
         weight: 20
         enabled: false
@@ -75,6 +89,12 @@ settings:
         enabled: false
       map:
         weight: 35
+        enabled: false
+      phasing:
+        weight: 49
+        enabled: true
+      phasing_item:
+        weight: 50
         enabled: false
       remote_video:
         weight: 36
@@ -85,9 +105,18 @@ settings:
       sidebar_text:
         weight: 38
         enabled: false
+      social_media_link:
+        weight: 54
+        enabled: false
       text:
         weight: 22
         enabled: true
+      unit_accessibility_information:
+        weight: 56
+        enabled: false
+      unit_contact_card:
+        weight: 57
+        enabled: false
       unit_search:
         weight: 40
         enabled: false


### PR DESCRIPTION
# [UHF-5844](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5844)
<!-- What problem does this solve? -->
There was missing configuration from the phasing paragraph that needed to be added so that the paragraph can be used.

## What was done
<!-- Describe what was done -->

* Added the paragraph available to basic page, landing page and accordion item paragraph.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-5844_add_missing_phasing_component_configuration`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] You should now be able to add phasing paragraph to upper and lower content on basic page, content on landing page and also inside accordion paragraph. These were not working previously.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)