### PR TITLE
UHF-6644: Change text for filtering Swedish service points

### DIFF
--- a/conf/cmi/language/fi/views.view.unit_search.yml
+++ b/conf/cmi/language/fi/views.view.unit_search.yml
@@ -6,12 +6,16 @@ display:
           group_info:
             group_items:
               1:
-                title: 'Näytä terveysasemat, joilta saan palvelua ruotsiksi'
+                title: 'Näytä toimipisteet, joilta saa palvelua ruotsiksi'
+          expose:
+            description: ''
+            placeholder: ''
         combine:
           expose:
             label: Etsi
           group_info:
             label: 'Kentät yhdistävä suodatin'
+            description: ''
       pager:
         options:
           tags:

--- a/conf/cmi/language/sv/views.view.unit_search.yml
+++ b/conf/cmi/language/sv/views.view.unit_search.yml
@@ -6,12 +6,15 @@ display:
           group_info:
             group_items:
               1:
-                title: 'Visa hälsostationer som erbjuder service på svenska'
+                title: 'Visa serviceställen som erbjuder service på svenska'
+          expose:
+            description: ''
+            placeholder: ''
         combine:
           expose:
             label: Sök
           group_info:
-            label: 'Combine fields filter'
+            description: ''
       pager:
         options:
           tags:

--- a/conf/cmi/views.view.unit_search.yml
+++ b/conf/cmi/views.view.unit_search.yml
@@ -720,7 +720,7 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: 'Show heath stations that provide service in Swedish'
+                title: 'Show service points that provide service in Swedish'
                 operator: '='
                 value: sv
         field_districts_target_id:
@@ -856,8 +856,8 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
         - user
+        - user.permissions
       tags: {  }
   block:
     id: block
@@ -875,8 +875,8 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user.permissions
         - user
+        - user.permissions
       tags: {  }
   entity_reference:
     id: entity_reference


### PR DESCRIPTION
# [UHF-6644](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6644)

## What was done
* Changed the filter text to a more generic one.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6644-unit-search-provide-swedish-text`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Go to a page that contains unit search.
* Check that there is an option: "Show service points that provide service in Swedish". The text does not refer to heath stations but to more generic service points.
* Also check the Finnish and Swedish translations.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
