### PR TITLE
UHF-8233: Sotebotti

### DIFF
--- a/conf/cmi/block.block.chatleijuke_3.yml
+++ b/conf/cmi/block.block.chatleijuke_3.yml
@@ -18,7 +18,7 @@ settings:
   label: 'Chat Leijuke'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: ''
+  chat_title: 'Sotebotti Hester'
   chat_selection: watson_sote
 visibility:
   request_path:


### PR DESCRIPTION
# [UHF-8233](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8233)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the name for the Hester sotebotti chat

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8233_sotebotti`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/mielenterveyspalvelut and check that the chat is now Sotebotti Hester
![image](https://user-images.githubusercontent.com/1712902/231949752-0ebb171c-db7f-4b09-96c6-83a89bb13916.png)



[UHF-8233]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ