### PR TITLE
UHF-8520 JS translation fix

### DIFF
--- a/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
+++ b/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
@@ -1,1 +1,1 @@
-((t,a)=>{t.behaviors.themeCommon={attach:function(){}}})(Drupal,drupalSettings);
+((Drupal,drupalSettings)=>{Drupal.behaviors.themeCommon={attach:function(){}}})(Drupal,drupalSettings);

--- a/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
+++ b/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
@@ -1,1 +1,0 @@
-((Drupal,drupalSettings)=>{Drupal.behaviors.themeCommon={attach:function(){}}})(Drupal,drupalSettings);

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
@@ -28,4 +28,3 @@ regions:
 # Libraries
 libraries:
   - hdbt_subtheme/global-styling
-#  - hdbt_subtheme/global-scripting

--- a/public/themes/custom/hdbt_subtheme/package-lock.json
+++ b/public/themes/custom/hdbt_subtheme/package-lock.json
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001486",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/public/themes/custom/hdbt_subtheme/src/js/common.js
+++ b/public/themes/custom/hdbt_subtheme/src/js/common.js
@@ -1,9 +1,0 @@
-// eslint-disable-next-line no-unused-vars
-((Drupal, drupalSettings) => {
-  Drupal.behaviors.themeCommon = {
-    attach: function attach() {
-      // Code here.
-    },
-  };
-  // eslint-disable-next-line no-undef
-})(Drupal, drupalSettings);

--- a/public/themes/custom/hdbt_subtheme/webpack.config.js
+++ b/public/themes/custom/hdbt_subtheme/webpack.config.js
@@ -142,6 +142,12 @@ module.exports = (env, argv) => {
           new TerserPlugin({
             terserOptions: {
               ecma: 2015,
+              mangle: {
+                reserved:[
+                  'Drupal',
+                  'drupalSettings'
+                ]
+              },
               format: {
                 comments: false,
               },


### PR DESCRIPTION
# [UHF-8520](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8520)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Stopped the TerserPlugin from minifying the variable names Drupal and drupalSettings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8520_js_translation_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the site theme still works as it should.
* [ ] Since there is no javascript that is used on the hdbt_subtheme this is just fix for not running into the issue in the future. You can check the testing instructions from hdbt PR.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/668
* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/132
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/371
* https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/248
* https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/241
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/380
* https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/174
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/643
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/262
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/585
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/460


[UHF-8520]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ