### PR TITLE
UHF-8390 D10 deprecation

### DIFF
--- a/public/modules/custom/helfi_sote/helfi_sote.info.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.info.yml
@@ -2,7 +2,6 @@ name: HELfi SOTE
 description: hel.fi SOTE specific funtionality
 type: module
 package: Custom
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_tpr:helfi_tpr

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.info.yml
@@ -3,7 +3,7 @@ description: Subtheme for Helsinki Drupal instances.
 type: theme
 base theme: hdbt
 tags: sub-theme
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 screenshot: hdbt_subtheme.png
 'interface translation project': hdbt_subtheme
 'interface translation server pattern': themes/custom/hdbt_subtheme/translations/%language.po


### PR DESCRIPTION
Updated core version requirements

How to test:
Setup the site normally
Go to front page and admin side status page
The site should work

You can also test the D10 readiness status by following these steps:
run `composer require drupal/upgrade_status` and `drush en -y upgrade_status`

Running these commands below should only yield prophesy/prophesize errors:
for all custom modules run `drush upgrade_status:analyze helfi_custom_module_name_here`
run `drush upgrade_status:analyze hdbt_subtheme`