### PR TITLE
UHF-X: Manually adding dependecy to jquery_ui and jquery_ui_draggable

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -89,6 +89,8 @@ module:
   imagecache_external: 0
   imagemagick: 0
   inline_form_errors: 0
+  jquery_ui: 0
+  jquery_ui_draggable: 0
   language: 0
   link: 0
   linkit: 0


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Manually adding dependency to jquery_ui and jquery_ui_draggable because focal point 2.0 requires them and it is already merged.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_focal_point_2.0_dependency`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure jquery_ui and jquery_ui_draggable are enabled.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
