### PR TITLE
UHF-X: Enable calculator paragraph on standard page for SOTE

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -5,3 +5,5 @@ ignored_config_entities:
   - 'easy_breadcrumb.settings:home_segment_title'
   - block.block.ibmchatapp
   - block.block.ibmchatapp_watson_sotebot_exceptions
+  - 'field.storage.paragraph.field_calculator:settings.allowed_values'
+  - helfi_calculator.calculator_settings

--- a/conf/cmi/core.entity_form_display.paragraph.calculator.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.calculator.default.yml
@@ -1,0 +1,32 @@
+uuid: 93f30881-f07a-4b9e-8c2e-39d88921d44b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.calculator.field_calculator
+    - field.field.paragraph.calculator.field_calculator_title
+    - paragraphs.paragraphs_type.calculator
+_core:
+  default_config_hash: 4Of9h7ovkWKwJnZsh4GLlyV35pilmuA6ukxjRZ1_nC4
+id: paragraph.calculator.default
+targetEntityType: paragraph
+bundle: calculator
+mode: default
+content:
+  field_calculator:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_calculator_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/conf/cmi/core.entity_view_display.paragraph.calculator.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.calculator.default.yml
@@ -1,0 +1,34 @@
+uuid: bac419dc-c19d-4405-a2c5-8485e5e5cbab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.calculator.field_calculator
+    - field.field.paragraph.calculator.field_calculator_title
+    - paragraphs.paragraphs_type.calculator
+  module:
+    - options
+_core:
+  default_config_hash: IV9HaopKVuXUhTly62bndhPetfg5MmB3FKOud1RqnNk
+id: paragraph.calculator.default
+targetEntityType: paragraph
+bundle: calculator
+mode: default
+content:
+  field_calculator:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_calculator_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -44,6 +44,7 @@ module:
   helfi_api_base: 0
   helfi_azure_fs: 0
   helfi_base_content: 0
+  helfi_calculator: 0
   helfi_ckeditor: 0
   helfi_eu_cookie_compliance: 0
   helfi_global_announcement: 0

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.calculator
     - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
@@ -61,12 +62,16 @@ settings:
       unit_contact_card: unit_contact_card
       unit_search: unit_search
       service_list_search: service_list_search
+      calculator: calculator
     negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: 0
         enabled: true
       banner:
+        weight: 0
+        enabled: true
+      calculator:
         weight: 0
         enabled: true
       chart:

--- a/conf/cmi/field.field.node.page.field_lower_content.yml
+++ b/conf/cmi/field.field.node.page.field_lower_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - node.type.page
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.calculator
     - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.contact_card_listing
@@ -61,12 +62,16 @@ settings:
       unit_contact_card: unit_contact_card
       unit_search: unit_search
       service_list_search: service_list_search
+      calculator: calculator
     negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: 0
         enabled: true
       banner:
+        weight: 0
+        enabled: true
+      calculator:
         weight: 0
         enabled: true
       chart:

--- a/conf/cmi/field.field.paragraph.calculator.field_calculator.yml
+++ b/conf/cmi/field.field.paragraph.calculator.field_calculator.yml
@@ -1,0 +1,25 @@
+uuid: bc263706-2e05-4f00-992d-6b62c7bacb03
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_calculator
+    - paragraphs.paragraphs_type.calculator
+  module:
+    - options
+_core:
+  default_config_hash: nC51dNmmyCVk7ig7qpYMOc69UxdmGo26EMF3HNe02Go
+id: paragraph.calculator.field_calculator
+field_name: field_calculator
+entity_type: paragraph
+bundle: calculator
+label: Calculator
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: disabled
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/cmi/field.field.paragraph.calculator.field_calculator_title.yml
+++ b/conf/cmi/field.field.paragraph.calculator.field_calculator_title.yml
@@ -1,0 +1,21 @@
+uuid: 15d9e89d-813e-4f77-871e-100862177d40
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_calculator_title
+    - paragraphs.paragraphs_type.calculator
+_core:
+  default_config_hash: 1vOlAAB-2tKwI8vgO2D9Z8MyC9GgxUgFftTXK0jwyUo
+id: paragraph.calculator.field_calculator_title
+field_name: field_calculator_title
+entity_type: paragraph
+bundle: calculator
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.paragraph.field_calculator.yml
+++ b/conf/cmi/field.storage.paragraph.field_calculator.yml
@@ -1,0 +1,23 @@
+uuid: dc2270f2-80b3-47ae-b588-43745eff93b2
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+_core:
+  default_config_hash: 8ttyUjXwYzU9Wtlyub9tIN-_lxaF5mV0rXomnfBPUGI
+id: paragraph.field_calculator
+field_name: field_calculator
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values: {  }
+  allowed_values_function: 'Drupal\helfi_calculator\Form\CalculatorSettings::getActiveCalculators'
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_calculator_title.yml
+++ b/conf/cmi/field.storage.paragraph.field_calculator_title.yml
@@ -1,0 +1,23 @@
+uuid: 4c262649-2519-4875-b4cd-365da3deaef5
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+_core:
+  default_config_hash: GjV7FfqAN65CsmDNefqd6mthq6-EnqtZUkjI5j-csX0
+id: paragraph.field_calculator_title
+field_name: field_calculator_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/helfi_calculator.settings.yml
+++ b/conf/cmi/helfi_calculator.settings.yml
@@ -1,0 +1,24 @@
+_core:
+  default_config_hash: g4xLZ2eKdkd2lO31Wp099a3bY5ZYZoE_xjR8BwROUMM
+langcode: en
+calculators:
+  home_care_service_voucher:
+    active: false
+    json: '{}'
+    label: 'Home care service voucher'
+  home_care_client_fee:
+    active: false
+    json: '{}'
+    label: 'Home care client fee'
+  continuous_housing_service_voucher:
+    active: false
+    json: '{}'
+    label: '24-hour housing service voucher'
+  families_home_services_client_fee:
+    active: false
+    json: '{}'
+    label: 'Families home services client fee'
+  early_childhood_education_fee:
+    active: false
+    json: '{}'
+    label: 'Early childhood education fee'

--- a/conf/cmi/language/fi/field.field.paragraph.calculator.field_calculator.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.calculator.field_calculator.yml
@@ -1,0 +1,1 @@
+label: Laskuri

--- a/conf/cmi/language/fi/field.field.paragraph.calculator.field_calculator_title.yml
+++ b/conf/cmi/language/fi/field.field.paragraph.calculator.field_calculator_title.yml
@@ -1,0 +1,1 @@
+label: Otsikko

--- a/conf/cmi/language/fi/helfi_calculator.settings.yml
+++ b/conf/cmi/language/fi/helfi_calculator.settings.yml
@@ -1,0 +1,11 @@
+calculators:
+  home_care_service_voucher:
+    label: 'Kotihoidon palvelusetelilaskuri'
+  home_care_client_fee:
+    label: 'Kotihoidon asiakasmaksun laskuri'
+  continuous_housing_service_voucher:
+    label: 'Palveluasumisen palvelusetelilaskuri'
+  families_home_services_client_fee:
+    label: 'Lapsiperheiden kotipalvelun asiakasmaksulaskuri'
+  early_childhood_education_fee:
+    label: 'Varhaiskasvatusmaksun laskuri'

--- a/conf/cmi/language/fi/paragraphs.paragraphs_type.calculator.yml
+++ b/conf/cmi/language/fi/paragraphs.paragraphs_type.calculator.yml
@@ -1,0 +1,2 @@
+label: Laskuri
+description: ''

--- a/conf/cmi/language/sv/field.field.paragraph.calculator.field_calculator.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.calculator.field_calculator.yml
@@ -1,0 +1,1 @@
+label: Räknare

--- a/conf/cmi/language/sv/field.field.paragraph.calculator.field_calculator_title.yml
+++ b/conf/cmi/language/sv/field.field.paragraph.calculator.field_calculator_title.yml
@@ -1,0 +1,1 @@
+label: Titel

--- a/conf/cmi/language/sv/paragraphs.paragraphs_type.calculator.yml
+++ b/conf/cmi/language/sv/paragraphs.paragraphs_type.calculator.yml
@@ -1,0 +1,2 @@
+label: Räknare
+description: ''

--- a/conf/cmi/paragraphs.paragraphs_type.calculator.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.calculator.yml
@@ -1,0 +1,17 @@
+uuid: 9bcc302e-8416-4ceb-bc87-bd7ab41e47d8
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs_library
+third_party_settings:
+  paragraphs_library:
+    allow_library_conversion: true
+_core:
+  default_config_hash: qPuITOAR6fQC3hedFhewKtZkjm93xFyGyYPgTOAiYRM
+id: calculator
+label: Calculator
+icon_uuid: null
+icon_default: null
+description: 'A paragraph that adds a predefined calculator to the page.'
+behavior_plugins: {  }

--- a/public/modules/custom/helfi_sote/helfi_sote.install
+++ b/public/modules/custom/helfi_sote/helfi_sote.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains SOTE installation hooks.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * UHF-X: Enable calculator paragraph on strandard page on SOTE-instance.
+ */
+function helfi_sote_update_9001(): void {
+  helfi_platform_config_update_paragraph_target_types();
+}

--- a/public/modules/custom/helfi_sote/helfi_sote.module
+++ b/public/modules/custom/helfi_sote/helfi_sote.module
@@ -55,10 +55,12 @@ function helfi_sote_helfi_paragraph_types() : array {
     'node' => [
       'page' => [
         'field_content' => [
+          'calculator',
           'unit_accessibility_information',
           'unit_contact_card',
         ],
         'field_lower_content' => [
+          'calculator',
           'unit_accessibility_information',
           'unit_contact_card',
         ],


### PR DESCRIPTION
# UHF-X: Enable calculator paragraph on standard page for SOTE
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Enabled calculator module and paragraph for standard page on SOTE.
* Added required configuration.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_enable_calculators`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that calculator module is enabled and you are able to add calculator paragraph to standard pages.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
