### PR TITLE
UHF-8981: Added test version for the suunte chat.

### DIFF
--- a/public/modules/custom/helfi_sote/assets/css/genesys_chat.css
+++ b/public/modules/custom/helfi_sote/assets/css/genesys_chat.css
@@ -1,0 +1,426 @@
+.cx-webchat.cx-theme-helsinki-blue {
+  right: 20px !important;
+  width: 500px;
+  font: 400 normal normal 20px/1.3 Arial, sans-serif;
+  color: white;
+  font-size: 20px;
+  background-color: white;
+  right: 20px !important;
+}
+
+.cx-theme-helsinki-blue .cx-common-container .cx-titlebar {
+  background-color: #0000bf;
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cx-theme-helsinki-blue .cx-common-container .cx-titlebar .cx-title {
+  margin-right: 70px;
+  text-align: center;
+  word-break: break-word;
+  font-size: 1.3em;
+}
+
+.cx-theme-helsinki-blue .cx-message-group {
+  position: relative;
+  margin: 10px 0px 0px 5px;
+}
+
+.cx-theme-helsinki-blue .cx-message-group:last-child {
+  padding-bottom: 50px;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message.cx-system {
+  margin: 0;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message {
+  min-height: 35px;
+  width: fit-content;
+}
+
+.cx-theme-helsinki-blue .cx-message.cx-participant {
+  max-width: 90%;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message .cx-time {
+  color: #d6d6d6;
+  display: block;
+  text-align: right;
+  margin-bottom: 0;
+  margin-top: 5px;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message.cx-system .cx-bubble,
+.cx-theme-helsinki-blue .cx-bubble {
+  display: flex;
+  flex-direction: column;
+  background-color: #0000bf;
+  border-radius: 0.4em;
+  padding: 0.5em;
+  border-bottom-left-radius: 0.4em !important;
+  border-bottom-right-radius: 0.4em !important;
+  border-top-left-radius: 0.4em !important;
+  border-top-right-radius: 0.4em !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message-group > .cx-message.cx-participant:last-child .cx-bubble,
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message-group > .cx-message.cx-participant:first-child .cx-bubble {
+  border-bottom-left-radius: 0.4em !important;
+  border-bottom-right-radius: 0.4em !important;
+  border-top-left-radius: 0.4em !important;
+  border-top-right-radius: 0.4em !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat div.cx-input-container {
+  border: none !important;
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 2px;
+  display: flex !important;
+  background-color: #f4f4f4 !important;
+  max-height: 44px;
+  box-shadow: none;
+  padding: 0px !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat div.cx-input-container .cx-textarea-cell {
+  position: relative;
+  border: none !important;
+  background-color: transparent !important;
+  height: 100%;
+  color: black;
+  width: 100%;
+}
+
+.cx-theme-helsinki-blue .cx-menu-cell {
+  display: none;
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message.cx-you,
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message .cx-name {
+  color: white;
+}
+
+.cx-theme-helsinki-blue svg {
+  fill: white;
+}
+
+.cx-theme-helsinki-blue .cx-bubble-arrow svg {
+  fill: #0000bf;
+}
+
+.cx-webchat .cx-transcript .cx-message .cx-bubble {
+  padding: 0.5em;
+}
+
+.cx-textarea-cell .cx-send.cx-icon,
+#gwc-chat-icon-iks-mobile {
+  background-color: unset;
+  border: unset;
+  border-radius: unset;
+  margin: unset;
+  padding: unset;
+  color: unset;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile .cx-message-input {
+  margin-top: 0px !important;
+  font-size: 0.9em !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile div.cx-input-container {
+  max-height: 50px;
+  padding: unset;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile .cx-body {
+  display: contents;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile .cx-body {
+  display: contents;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile .cx-alert {
+  margin-top: 102px;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile div.cx-input-container .cx-message-input {
+  max-height: unset;
+  overflow: scroll !important;
+  min-height: 30px;
+  padding: 0px 65px 0px 0px !important;
+}
+
+.cx-theme-helsinki-blue #cx_chat_error_desc {
+  color: black;
+}
+
+.cx-theme-helsinki-blue .cx-webchat.cx-mobile div.cx-input-container .cx-input-focus {
+  bottom: 0px;
+}
+
+.cx-theme-helsinki-blue .cx-button-group.cx-buttons-window-control .cx-icon {
+  border-radius: unset;
+}
+
+.cx-textarea-cell .cx-send.cx-icon svg {
+  fill: black;
+}
+
+.cx-theme-helsinki-blue .cx-webchat div.cx-input-container .cx-message-input {
+  padding: 14px 16px 27px 24px;
+  margin-bottom: 0px;
+  min-height: 55px !important;
+  /* height: 40px;
+        padding-top: 0px;
+        padding-bottom: 0px;
+        border-width: 0px;
+        max-height: 20px; */
+}
+
+.cx-theme-helsinki-blue .cx-webchat .cx-transcript .cx-message .cx-message-text {
+  word-break: break-word;
+}
+
+.cx-theme-helsinki-blue .cx-common-container .cx-buttons-window-control button {
+  width: 25px;
+  height: 25px;
+}
+
+#chatAuthenticationElement,
+#helfiChatAuthElementDone {
+  height: 50px;
+  background-color: royalblue;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: 400 normal normal 16px/1.3 Arial, sans-serif;
+  margin-top: -1px;
+}
+
+#chatAuthenticationElement a,
+#helfiChatAuthElementDone a {
+  color: white;
+}
+
+.gwc-chat-logo-helsinki {
+  width: 70px;
+}
+
+.cx-theme-helsinki-blue .cx-side-button-group {
+  bottom: 0;
+  -webkit-transform: unset;
+  z-index: 100 !important;
+}
+
+.cx-widget.cx-webchat-chat-button.cx-side-button.cx-theme-helsinki-blue {
+  background-position: bottom right !important;
+  display: flex;
+  background-repeat: no-repeat !important;
+  background-color: transparent !important;
+  width: 150px;
+  height: 114px;
+  background: none;
+  border: none;
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+  transition: none;
+}
+
+@media only screen and (max-width: 575px) {
+  cx-widget.cx-webchat-chat-button.cx-side-button.cx-theme-helsinki-blue,
+  .cx-widget.cx-webchat-chat-button.cx-side-button.cx-theme-helsinki-blue:hover {
+    width: 114px !important;
+  }
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-open {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-open.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-busy {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-busy.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-closed {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-closed.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-open-sv {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-open-sv.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-busy-sv {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-busy-sv.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-closed-sv {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-closed-sv.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-open-en {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-open-en.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-busy-en {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-busy-en.png) !important;
+}
+
+.cx-theme-helsinki-blue .cx-webchat-chat-button-closed-en {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/chat-closed-en.png) !important;
+}
+
+.cx-webchat-chat-button-mobile-open {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/mobile_open1.svg) !important;
+}
+
+.cx-webchat-chat-button-mobile-busy {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/mobile_busy1.svg) !important;
+}
+
+.cx-webchat-chat-button-mobile-closed {
+  background-image: url(https://www.hel.fi/static/helsinki/chat/mobile_closed_strike1.svg) !important;
+}
+
+.cx-widget.cx-webchat-chat-button.cx-side-button.cx-theme-helsinki-blue .cx-icon,
+.cx-widget.cx-webchat-chat-button.cx-side-button.cx-theme-helsinki-blue .cx-chat-button-label {
+  display: none;
+}
+
+.cx-theme-helsinki-blue .cx-avatar.user svg {
+  fill: black;
+}
+
+.cx-webchat.cx-theme-helsinki-blue .cx-transcript .cx-message-group > .cx-message.cx-participant .cx-avatar-wrapper {
+  display: block !important;
+  left: 100%;
+}
+
+.cx-webchat.cx-theme-helsinki-blue .cx-transcript .cx-message-group > .cx-message.cx-participant .cx-bubble-arrow,
+.cx-webchat.cx-theme-helsinki-blue .cx-transcript .cx-message-group > .cx-message.cx-participant .cx-time {
+  display: block !important;
+}
+
+.cx-webchat.cx-theme-helsinki-blue .cx-transcript .cx-message-group > .cx-message.cx-participant:first-child .cx-name {
+  display: none !important;
+}
+
+.cx-webchat.cx-theme-helsinki-blue .cx-transcript .cx-avatar {
+  width: 40px;
+}
+
+.cx-widget.cx-theme-helsinki-blue .cx-side-button-group {
+  top: unset;
+}
+
+.cx-theme-helsinki-blue .cx-widget-status {
+  display: none;
+}
+
+#cx_chat_end_question {
+  margin-top: 4%;
+  text-align: center;
+  color: black;
+}
+
+.cx-theme-helsinki-blue .cx-button-group.cx-buttons-binary {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.cx-theme-helsinki-blue .cx-buttons-binary .cx-btn {
+  background-color: #0000bf;
+}
+
+#gwc-chat-icon-iks-mobile {
+  width: 50px;
+  cursor: pointer;
+  position: fixed;
+  bottom: 58px;
+  right: 5px;
+  filter: invert(100%);
+  z-index: 99999999 !important;
+  box-shadow: unset;
+}
+
+.cx-theme-helsinki-blue .cx-form-wrapper {
+  display: none !important;
+}
+
+.cx-theme-helsinki-blue .cx-textarea-cell {
+  display: flex;
+  align-items: flex-end;
+}
+
+#cx_input {
+  padding: 12px !important;
+  margin: 0 !important;
+  flex: 6;
+  position: relative;
+  max-height: 49px;
+}
+
+.cx-send.cx-icon.i18n svg {
+  width: 35px;
+}
+
+.cx-send.cx-icon.i18n {
+  position: relative;
+  flex: 1;
+  right: auto;
+  height: 46px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.cx-Agent .cx-avatar-wrapper {
+  display: block !important;
+  left: -3% !important;
+  position: absolute;
+  width: 50px !important;
+}
+
+.cx-avatar.agent svg {
+  fill: black;
+}
+
+.cx-message-text {
+  color: white;
+}
+
+.cx-powered-by {
+  display: none;
+}
+
+.cx-widget.cx-common-container.cx-toast.cx-theme-helsinki-blue {
+  background-color: white;
+}
+
+.cx-widget.cx-common-container.cx-toast.cx-theme-helsinki-blue .cx-titlebar,
+.cx-widget.cx-common-container.cx-toast.cx-theme-helsinki-blue .cx-button-group.cx-buttons-binary {
+  color: white;
+}
+
+.cx-title {
+  font-size: 0.9em !important;
+  font-family: "HelsinkiGroteskBlack", "Arimo-Bold", sans-serif;
+}
+
+.cx-input-focus {
+  outline: -webkit-focus-ring-color auto 1px !important;
+}
+
+.cx-send {
+  min-height: 55px;
+}
+
+.cx-widget img[src$="close-next.svg"] {
+  max-width: 100%;
+}

--- a/public/modules/custom/helfi_sote/assets/js/genesys_auth_redirect_test.js
+++ b/public/modules/custom/helfi_sote/assets/js/genesys_auth_redirect_test.js
@@ -1,0 +1,120 @@
+function isEmpty(str) {
+    return (!str || 0 === str.length);
+}
+
+function isBlank(str) {
+    return (!str || /^\s*$/.test(str));
+}
+
+String.prototype.isEmpty = function() {
+    return (this.length === 0 || !this.trim());
+};
+
+function getCookieChat(cname) {
+    var name = cname + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
+
+function callShibboleth()
+{
+    var interactionId = '';
+    interactionId = getCookieChat("gcReturnSessionId");
+	//Current url without querystring:
+	var currentPage = location.toString().replace(location.search, "");
+	var shibbolethString = "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+	shibbolethString += "target=";
+    shibbolethString += "https://chat-proxy.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
+	console.log('currentPage:'+currentPage);
+    shibbolethString += "%3ForigPage%3D" + currentPage + "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+	shibbolethString += "%26" + "interactionId" + "%3D" + interactionId;
+	window.location = shibbolethString;
+}
+
+var _genesys = {
+    onReady: [],
+    chat: {
+        registration: false,
+        localization : 'https://chat-proxy.hel.fi/gms/sote/localization/chat-testisivu-fi.json',
+        onReady: [],
+        ui: {
+            onBeforeChat: function (chat) {
+                _genesys.chat.onReady.push(function (chatWidgetApi) {
+                    chatWidgetApi.restoreChat({
+                        serverUrl: "https://chat-proxy.hel.fi/chat/sote/cobrowse",
+                        registration: function (done) {
+                            done({
+                                 service: 'TESTISIVU_TESTI'
+                            });
+                        }
+                    }).done(function (session) {
+                        session.setUserData({
+                           service: 'TESTISIVU_TESTI'
+                        });
+                    }).fail(function (par) {
+                        alert(par.description);
+                    });
+                });
+            }
+        }
+    }
+};
+_genesys.cobrowse = false;
+
+
+var url = window.location.search;
+url = decodeURIComponent(url);
+var referringURL = '';
+var returnURL = '';
+
+/* FILL HERE DRUPAL URL SCOPE UNDER WHICH SUUNTE CHAT IS RUN, COOKIE WOULD BE GOOD TO HAVE URL CONTEXT AS WELL IF MULTIPLE GENESYS CHATS ARE RUN UNDER SAME DOMAIN */
+var helfiChatCookiePath = '/fi/sosiaali-ja-terveyspalvelut/';
+
+// show authenticate button 0 no, 1 yes:
+var int_gcLoginButtonState=0;
+
+// dir = out => transfer to authentication
+if(url.indexOf('?dir=out') !== -1){
+  referringURL = document.referrer;
+  //setting helper cookie return url:
+  document.cookie = "gcReturnUrl="+referringURL+";path="+helfiChatCookiePath;
+  callShibboleth();
+}
+
+// dir = in => transfer to back to hel.fi -site from authentication
+if(url.indexOf('?dir=in') !== -1){
+  // set gcLoginButtonState -info cookie, if user has authenticated=1, or not..
+    var now = new Date();
+    var time = now.getTime();
+   int_gcLoginButtonState=1;
+    time += 180 * 1000;
+    now.setTime(time);
+   document.cookie = "gcLoginButtonState="+int_gcLoginButtonState +"; expires=" + now.toUTCString() +";path="+helfiChatCookiePath;
+
+  // get return url back from hel.fi cookie:
+  returnURL = getCookieChat("gcReturnUrl");
+
+  // redirect urser back from Vetuma, to hel.fi -site:
+  // prevent endless loop, do not redirect back to this transfer page itself!
+  if(returnURL!="" && returnURL.indexOf('transfer') == -1 && !isEmpty(returnURL) && !isBlank(returnURL)){
+     window.location.href = returnURL + '?redir=done';
+  }
+  else{
+    // search alternative returnURl cookie, set by hel.fi chat page before user clicked authenticate link:
+     returnURL = getCookieChat("gcAlternativeReturnUrl");
+       if(returnURL!="" && returnURL.indexOf('transfer') == -1 && !isEmpty(returnURL) && !isBlank(returnURL)){
+          window.location.href = returnURL + '?redir2=done';
+      }
+    // default fallback: some error happened. Redirect back to top level contextual main page:
+     window.location = helfiChatCookiePath + '?redir3=done';
+  }
+}

--- a/public/modules/custom/helfi_sote/assets/js/genesys_suunte_test.js
+++ b/public/modules/custom/helfi_sote/assets/js/genesys_suunte_test.js
@@ -1,0 +1,440 @@
+var helfiChatCookiePath = '/fi/sosiaali-ja-terveyspalvelut/';
+var helfiChatTransferPath = helfiChatCookiePath + 'genesys-auth-redirect-test?dir=out';
+var gcReturnSessionId = '';
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.removeChatIcon = function() {
+    $(".cx-window-manager").css("display", "none");
+  }
+
+  Drupal.setGcReturnSessionId = function() {
+    // helper cookie to maintain chat session id:
+    var gcReturnSessionId = Drupal.getCookieChat("_genesys.widgets.webchat.state.session");
+    if (!Drupal.isEmpty(gcReturnSessionId) && !Drupal.isBlank(gcReturnSessionId)) {
+      // Found GS-chat session, setting it to helper cookie:
+      /* document.cookie = "gcReturnSessionId="+gcReturnSessionId+";path=/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/"; */
+      document.cookie =
+        "gcReturnSessionId=" + gcReturnSessionId + ";path=" + helfiChatCookiePath;
+    } else {
+      //console.log("gcReturnSessionId", gcReturnSessionId);
+      alert(
+        "Virhe, ei voida tunnistaa käyttäjää, koska chat-keskustelu ei ole auki."
+      );
+      return false;
+    }
+    // save alternative return url for cookie:
+    document.cookie =
+      "gcAlternativeReturnUrl=" +
+      window.location.href +
+      ";path=" +
+      helfiChatCookiePath;
+    return true;
+  }
+
+  Drupal.getCookieChat = function(cname) {
+    var name = cname + "=";
+    var ca = document.cookie.split(";");
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == " ") {
+        c = c.substring(1);
+      }
+      if (c.indexOf(name) == 0) {
+        return c.substring(name.length, c.length);
+      }
+    }
+    return "";
+  }
+
+  Drupal.isEmpty = function(str) {
+        return !str || 0 === str.length;
+  }
+
+  Drupal.isBlank = function(str) {
+    return !str || /^\s*$/.test(str);
+  }
+
+  Drupal.behaviors.genesys_suunte = {
+    attach: function (context, settings) {
+      var helFiChatPageUrl = document.location.href;
+      helFiChatPageUrl = helFiChatPageUrl.toLowerCase();
+      var helfiChat_lang = document.documentElement.lang;
+
+      var accesabilityTexts = {
+        fi: {
+          userIconAlt: "käyttäjä",
+          agentIconAlt: "agentti",
+        },
+        en: {
+          userIconAlt: "user",
+          agentIconAlt: "agent",
+        },
+        sv: {
+          userIconAlt: "användare",
+          agentIconAlt: "ombud",
+        },
+      };
+
+      var startChatButtonClasses = {
+        desktop: {
+          fi: {
+            open: "cx-webchat-chat-button-open",
+            busy: "cx-webchat-chat-button-busy",
+            close: "cx-webchat-chat-button-closed",
+          },
+          sv: {
+            open: "cx-webchat-chat-button-open-sv",
+            busy: "cx-webchat-chat-button-busy-sv",
+            close: "cx-webchat-chat-button-closed-sv",
+          },
+          en: {
+            open: "cx-webchat-chat-button-open-en",
+            busy: "cx-webchat-chat-button-busy-en",
+            close: "cx-webchat-chat-button-closed-en",
+          },
+        },
+        mobile: {
+          fi: {
+            open: "cx-webchat-chat-button-mobile-open",
+            busy: "cx-webchat-chat-button-mobile-busy",
+            close: "cx-webchat-chat-button-mobile-closed",
+          },
+          sv: {
+            open: "cx-webchat-chat-button-mobile-open-sv",
+            busy: "cx-webchat-chat-button-mobile-busy-sv",
+            close: "cx-webchat-chat-button-mobile-closed-sv",
+          },
+          en: {
+            open: "cx-webchat-chat-button-mobile-open",
+            busy: "cx-webchat-chat-button-mobile-busy",
+            close: "cx-webchat-chat-button-mobile-closed",
+          },
+        },
+      };
+
+      var authEnabled = true;
+      var helfiChatLogoElement =
+        '<img class="gwc-chat-logo-helsinki" tabindex="0" title="helsinki-logo" alt="helsinki-logo" src="https://www.hel.fi/static/helsinki/chat/project-logo-hki-white-fi.png"/>';
+
+      var mobileIksButton =
+        '<div id="gwc-chat-icon-iks-mobile"' +
+        'tabindex="0" onkeypress="onEnter(event, this)" role="button" onclick="Drupal.removeChatIcon()"><img src="https://www.hel.fi/static/helsinki/chat/close-next.svg" /><div></div></div';
+      var helFiChat_SendButton = '<img class = "hki-cx-send-icon" src="https://www.hel.fi/static/helsinki/chat/arrow_black.svg" />';
+      var helFiChat_AgentIcon = '<img class = "hki-cx-avatar-icon" src="https://www.hel.fi/static/helsinki/chat/agent_blue.svg" alt="${accesabilityTexts[helfiChat_lang].agentIconAlt}" />';
+      var helFiChat_UserIcon = '<img class="hki-cx-avatar-icon" src="https://www.hel.fi/static/helsinki/chat/user_black.svg" alt="${accesabilityTexts[helfiChat_lang].userIconAlt}" />';
+
+      /* CHAT START BUTTON ICONS */
+      var helFiChat_button = "";
+      var helFiChat_localization =
+        "https://chat-proxy.hel.fi/gms/sote/localization/chat-testisivu-fi.json";
+      var helFiChat_service = "TESTISIVU_TESTI"; //SUUNTE
+      var helFiChat_language = "fi";
+      var helfiChat_GUI_lang = helFiChat_language;
+      var helFiChat_title = "Hammashoidon chat";
+
+	    /* FILL BELOW LINE CORRECT PATH WHERE CALLSHIBBOLETH FUNCTION IS RUN OR FUNCTION ITSELF?: */
+      var helfiChatAuthElement = '<div id="chatAuthenticationElement"><a href="javascript:void(0);" title="" target="" onclick="var testReturnSessionId=Drupal.setGcReturnSessionId();if(testReturnSessionId){window.location=helfiChatTransferPath;}" href="javascript:void(0);">Tunnistaudu tästä</a></div>';
+      var helfiChatAuthElementDone = '<div id="authUserTitleContainer" style="display: none;">Tunnistautunut käyttäjä</div>';
+
+
+      function callShibboleth() {
+        var interactionId = readInteractionIDFromCookie(
+          "_genesys.widgets.webchat.state.session"
+        );
+        var currentPage = window.location;
+        var shibbolethString =
+          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+        shibbolethString += "target=";
+        shibbolethString +=
+          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+        /*
+              shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+              */
+        shibbolethString +=
+          "%3ForigPage%3Dhttps://www.hel.fi" +
+          helfiChatTransferPath +
+          "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+        shibbolethString += "%26interactionId%3D" + interactionId;
+        window.location = shibbolethString;
+      }
+
+      function initHelFiChatAuthButtonState() {
+        // State of Vetuma authentication result:
+        gcReturnSessionId = Drupal.getCookieChat("gcSession");
+        // is user authenticated, 1=yes
+        var chatGcLoginButtonState = Drupal.getCookieChat("gcLoginButtonState");
+        //is genesys original session active now?
+        var gcOriginalSessionID = "";
+        gcOriginalSessionID = Drupal.getCookieChat("_genesys.widgets.webchat.state.session");
+        if (gcOriginalSessionID) {
+          setTimeout(function () {
+            // if(chatGcLoginButtonState==1) {
+            if (
+              chatGcLoginButtonState == 1 &&
+              document.getElementById("chatAuthenticationElement")
+            ) {
+              //user is authenticated, show correct link in chat window:
+              document.getElementById("chatAuthenticationElement").style.display =
+                "none";
+              document.getElementById("authUserTitleContainer").style.display = "";
+              document.getElementById("authUserTitleContainer").style.display =
+                "flex";
+            }
+            // else {
+            else if (document.getElementById("chatAuthenticationElement")) {
+              //user is not authenticated, show correct link in chat window:
+              document.getElementById("chatAuthenticationElement").style.display = "";
+              document.getElementById("chatAuthenticationElement").style.display =
+                "flex";
+              document.getElementById("authUserTitleContainer").style.display =
+                "none";
+            }
+          }, 2000); /* setTimeout */
+        }
+      } /* ...end function initHelFiChatAuthButtonState() */
+
+      window.addEventListener("load", initHelFiChatAuthButtonState);
+
+      // ------- Auth functions starts ------------
+
+      // ------- Auth functions ends ------------
+
+      function isMobile() {
+        if (screen.width < 600) {
+          return true;
+        }
+        return false;
+      }
+
+      (function setChatStartButton() {
+        //Check if it's mobile
+        var screenType = isMobile() ? "mobile" : "desktop";
+
+        helFiChat_button = "";
+        if (helFiChat_button.indexOf("chat-closed") > -1) {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].close;
+        } else if (helFiChat_button.indexOf("chat-busy") > -1) {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].busy;
+        } else {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].open;
+        }
+      })();
+
+      function generateStartChatButton() {
+        // var screenType = isMobile();
+        // // var mobileIksButton = '<div id="gwc-chat-icon-iks-mobile"' +
+        // //             'tabindex="0" onkeypress="onEnter(event, this)" role="button" onclick="removeChatIcon()"><img src="https://www.hel.fi/static/helsinki/chat/close-next.svg" /></div>'
+
+        var buttonHtml =
+          '<div class="cx-widget cx-webchat-chat-button ' +
+          helFiChat_button +
+          ' cx-side-button" id="chatButtonStart" role="button" tabindex="0" data-message="ChatButton"' +
+          'data-gcb-service-node="true"><span class="cx-icon" data-icon="chat"></span><span class="i18n cx-chat-button-label" data-message="ChatButton"></span></div>';
+        return buttonHtml;
+      }
+
+      if (!window._genesys) { window._genesys = {};
+      }
+      if (!window._gt) { window._gt = [];
+      }
+
+      window._genesys.widgets = {
+        main: {
+          theme: "helsinki-blue",
+          themes: {
+            "helsinki-blue": "cx-theme-helsinki-blue",
+          },
+          mobileMode: "auto",
+          lang: helfiChat_lang,
+          i18n: helFiChat_localization,
+          mobileModeBreakpoint: 600,
+          preload: ["webchat"],
+        },
+        webchat: {
+          dataURL: "https://chat-proxy.hel.fi/gms/sote/genesys/2/chat/prod",
+          confirmFormCloseEnabled: false,
+          userData: {
+            service: helFiChat_service,
+          },
+          timeFormat: 24,
+          cometD: {
+            enabled: false,
+          },
+          autoInvite: {
+            enabled: false,
+            timeToInviteSeconds: 10,
+            inviteTimeoutSeconds: 30,
+          },
+          chatButton: {
+            enabled: true,
+            template: generateStartChatButton(),
+            effect: "fade",
+            openDelay: 1000,
+            effectDuration: 300,
+            hideDuringInvite: true,
+          },
+          uploadEnabled: false,
+        },
+      };
+
+      if (!window._genesys.widgets.extensions) {
+        window._genesys.widgets.extensions = {};
+      }
+      var chatExtension = null;
+      chatExtension = CXBus.registerPlugin("ChatExt");
+
+      window._genesys.widgets.extensions["ChatExt"] = function ($, CXBus, Common) {
+        chatExtension.before("WebChat.open", function (oData) {
+          //Delete X button in mobile view
+          //console.log("restarted from open");
+          $("#gwc-chat-icon-iks-mobile").css("display", "none");
+
+          if (!oData.restoring) {
+            oData = {
+              form: {
+                autoSubmit: true,
+                nickname: "Asiakas",
+              },
+              formJSON: {
+                //wrapper: '<table style="display:none;"></table>',
+                inputs: [
+                  {
+                    id: "cx_webchat_form_nickname",
+                    name: "nickname",
+                    maxlength: "100",
+                    value: "Asiakas",
+                    type: "hidden",
+                  },
+                ],
+              },
+              userData: {
+                service: helFiChat_service,
+              },
+            };
+          }
+
+          //console.log(oData);
+          return oData;
+        });
+
+        //Triggers when chat is opened
+        chatExtension.subscribe("WebChat.opened", function (e) {
+          //Add auth layout
+          if (authEnabled) {
+            $(".cx-body").prepend(helfiChatAuthElement);
+            $(".cx-body").prepend(helfiChatAuthElementDone);
+          }
+
+          //Add logo
+          $(".cx-titlebar .cx-icon").replaceWith(helfiChatLogoElement);
+
+          $(".cx-input-container").removeAttr("tabindex").removeAttr("aria-hidden");
+          $(".cx-textarea-cell").removeAttr("tabindex").removeAttr("aria-hidden");
+          $(".cx-send").attr("tabindex", 0);
+          $(".cx-send").removeAttr("aria-hidden");
+
+          //Delete X button in mobile view
+          $("#gwc-chat-icon-iks-mobile").css("display", "none");
+          setTimeout(function () {
+            $("#gwc-chat-icon-iks-mobile").css("display", "none");
+          }, 500);
+
+          //Add accesability enchanced features on minimize
+          if ($("[data-icon=minimize]").length) {
+            $("[data-icon=minimize]").attr("aria-expanded", true);
+          }
+
+          //Change send icon
+          if ($(".cx-send").length) {
+            $(".cx-send").empty().append(helFiChat_SendButton);
+          }
+
+          //Change user icon
+          handleChangeAvatarIcons();
+
+          if ($(".cx-message-input.cx-input").length) {
+            $(".cx-message-input.cx-input").attr("tabindex", 0);
+          }
+        });
+
+        function minimizeAccesibilityChange(name) {
+          //Minimizdd button accesibility change
+          var minimizeElement = $(".cx-button-" + name);
+          if (minimizeElement) {
+            var ariaExpanded = JSON.parse(minimizeElement.attr("aria-expanded"));
+            minimizeElement.attr("aria-expanded", !ariaExpanded);
+          }
+        }
+
+        //Triggers when chat is ready to accept commands
+        chatExtension.subscribe("WebChat.ready", function (e) {
+          if (isMobile()) {
+            setTimeout(function () {
+              //showButton(true);
+              if ($(".cx-webchat-chat-button").length) {
+                $(".cx-side-button-group").prepend(mobileIksButton);
+              }
+            }, 3000);
+          }
+        });
+
+        // Remove custom visibility logic and show button upon closing chat
+        chatExtension.subscribe("WebChat.closed", function (e) {
+          if (isMobile()) {
+            setTimeout(function () {
+              if ($(".cx-webchat-chat-button").length) {
+                $(".cx-side-button-group").prepend(mobileIksButton);
+              }
+            }, 3000);
+          }
+        });
+
+        chatExtension.subscribe("WebChat.cancelled", function (e) {
+          // cancelled event. The Chat session ended before agent is connected to WebChat.
+          setTimeout(function () {
+            chatExtension
+              .command("WebChat.close")
+              .done(function (e) {
+                // closing success
+              })
+              .fail(function (e) {
+                // closing failure
+              });
+          }, 1000);
+        });
+
+        chatExtension.subscribe("WebChat.minimized", function (e) {
+          minimizeAccesibilityChange("maximize");
+        });
+
+        chatExtension.subscribe("WebChat.unminimized", function (e) {
+          minimizeAccesibilityChange("minimize");
+        });
+
+        chatExtension.subscribe("WebChat.messageAdded", function (event) {
+          handleChangeAvatarIcons();
+        });
+
+        function handleChangeAvatarIcons() {
+          //Change user icon
+          if ($(".cx-avatar.user").length) {
+            $(".cx-avatar.user").empty().append(helFiChat_UserIcon);
+          }
+
+          //Change agent icons
+          if ($(".cx-avatar.agent").length) {
+            $(".cx-avatar.agent").empty().append(helFiChat_AgentIcon);
+          }
+        }
+
+        chatExtension.republish("ready");
+        chatExtension.ready();
+        window.chatExtension = chatExtension;
+
+      };
+    }
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/public/modules/custom/helfi_sote/helfi_sote.libraries.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.libraries.yml
@@ -1,0 +1,40 @@
+genesys_suunte_test:
+  version: 1.0.0
+  header: true
+  js:
+    'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
+      type: external,
+      minified: true,
+      attributes: {
+        onload: "javascript:CXBus.configure({pluginsPath:'https://apps.mypurecloud.ie/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
+      }
+    }
+    assets/js/genesys_suunte_test.js: {
+      attributes: {
+        onload: "javascript:var checkExist = setInterval(function() {if(typeof CXBus != 'undefined') {clearInterval(checkExist);Drupal.behaviors.genesys_suunte.attach();console.log('suunte test attaching');}}, 100);"
+      }
+    }
+  css:
+    theme:
+      assets/css/genesys_chat.css: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+
+genesys_auth_redirect_test:
+  version: 1.0.0
+  header: true
+  js:
+    'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
+      type: external,
+      minified: true,
+      attributes: {
+        onload: "javascript:CXBus.configure({pluginsPath:'https://apps.mypurecloud.ie/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
+      }
+    }
+    assets/js/genesys_auth_redirect_test.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings

--- a/public/modules/custom/helfi_sote/helfi_sote.routing.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.routing.yml
@@ -1,0 +1,7 @@
+helfi_sote.genesys_auth_redirect_test:
+  path: '/genesys-auth-redirect-test'
+  defaults:
+    _controller: '\Drupal\helfi_sote\Controller\GenesysAuthRedirectControllerTesting::content'
+    _title: 'Genesys auth redirect test'
+  requirements:
+    _permission: 'access content'

--- a/public/modules/custom/helfi_sote/src/Controller/GenesysAuthRedirectControllerTesting.php
+++ b/public/modules/custom/helfi_sote/src/Controller/GenesysAuthRedirectControllerTesting.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\helfi_sote\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Genesys auth redirect controller.
+ */
+class GenesysAuthRedirectControllerTesting extends ControllerBase {
+
+  /**
+   * Returns a renderable array with attached JavaScript.
+   */
+  public function content() {
+    $build = [
+      '#markup' => $this->t('Redirecting...'),
+      '#attached' => [
+        'library' => ['helfi_sote/genesys_auth_redirect_test'],
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/public/modules/custom/helfi_sote/src/Plugin/Block/SuunteTest.php
+++ b/public/modules/custom/helfi_sote/src/Plugin/Block/SuunteTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\helfi_sote\Plugin\Block;
+
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Provides a Chat Leijuke block.
+ *
+ * @Block(
+ *  id = "suunte_test",
+ *  admin_label = @Translation("SUUNTE TEST"),
+ * )
+ */
+class SuunteTest extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    $form['chat_selection'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Chat/bot provider'),
+      '#description' => $this->t('Choose the approriate chat/bot provider?'),
+      '#default_value' => $config['chat_selection'] ?? '',
+      '#options' => [
+        'genesys_suunte_test' => 'Genesys SUUNTE TEST',
+      ],
+    ];
+
+    $form['chat_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chat title'),
+      '#default_value' => $config['chat_title'] ?? '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $formState) {
+    $this->configuration['chat_selection'] = $formState->getValue('chat_selection');
+    $this->configuration['chat_title'] = $formState->getValue('chat_title');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $library = ['helfi_platform_config/chat_leijuke'];
+    $config = $this->getConfiguration();
+    $build = [];
+    $chatLibrary = [];
+    $modulePath = \Drupal::service('extension.list.module')->getPath('helfi_sote');
+    $assetPath = \Drupal::config('helfi_proxy.settings')->get('asset_path');
+
+    $librariesYml = Yaml::parseFile($modulePath . '/helfi_sote.libraries.yml');
+
+    foreach ($librariesYml as $k => $lib) {
+      if ($k === $config['chat_selection']) {
+        if (array_key_exists('js', $lib)) {
+          foreach ($lib['js'] as $key => $value) {
+            $js = [
+              'url' => $key,
+              'ext' => $value['type'] ?? FALSE,
+              'onload' => $value['attributes']['onload'] ?? FALSE,
+              'async' => $value['attributes']['async'] ?? FALSE,
+              'data_container_id' => $value['attributes']['data-container-id'] ?? FALSE,
+            ];
+
+            $chatLibrary['js'][] = $js;
+          }
+        }
+        if (array_key_exists('css', $lib)) {
+          foreach ($lib['css']['theme'] as $key => $value) {
+            $css = [
+              'url' => $key,
+              'ext' => $value['type'] ?? FALSE,
+            ];
+
+            $chatLibrary['css'][] = $css;
+          }
+        }
+      }
+    }
+
+    // We only build it if it makes sense.
+    if ($config['chat_selection']) {
+      $build['leijuke'] = [
+        '#title' => $this->t('Chat Leijuke'),
+        '#attached' => [
+          'library' => $library,
+          'drupalSettings' => [
+            'leijuke_data' => [
+              $config['chat_selection'] => [
+                'name' => $config['chat_selection'],
+                'libraries' => $chatLibrary,
+                'modulepath' => $assetPath . '/' . $modulePath,
+                'title' => $config['chat_title'] ? Xss::filter($config['chat_title']) : 'Chat',
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
# [UHF-8981](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8981)
<!-- What problem does this solve? -->
TietoEvry needs the suunte chat test version on the site for some authentication testing.

## What was done
<!-- Describe what was done -->

* Added new option for the chat leijuke and test assets for the suunte chat.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `git checkout UHF-8981_suunte-test`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add the SUUNTE TEST -block to any page and choose the Genesys SUUNTE TEST option for it.
* [x] Test that the chat loads and opens when clicked. Some testing text should appear.
* [x] Check that code follows our standards
* [x] Check if there's something that would affect the other chats. This code should be safe to go even to the production without affecting anything unless this block is added to a page.


[UHF-8981]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ