### PR TITLE
UHF-X: Added a test chat with old auth URL domain.

### DIFF
--- a/public/modules/custom/helfi_sote/assets/js/genesys_auth_redirect_test_old.js
+++ b/public/modules/custom/helfi_sote/assets/js/genesys_auth_redirect_test_old.js
@@ -1,0 +1,120 @@
+function isEmpty(str) {
+    return (!str || 0 === str.length);
+}
+
+function isBlank(str) {
+    return (!str || /^\s*$/.test(str));
+}
+
+String.prototype.isEmpty = function() {
+    return (this.length === 0 || !this.trim());
+};
+
+function getCookieChat(cname) {
+    var name = cname + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
+
+function callShibboleth()
+{
+    var interactionId = '';
+    interactionId = getCookieChat("gcReturnSessionId");
+	//Current url without querystring:
+	var currentPage = location.toString().replace(location.search, "");
+	var shibbolethString = "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+	shibbolethString += "target=";
+    shibbolethString += "https://asiointi.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
+	console.log('currentPage:'+currentPage);
+    shibbolethString += "%3ForigPage%3D" + currentPage + "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+	shibbolethString += "%26" + "interactionId" + "%3D" + interactionId;
+	window.location = shibbolethString;
+}
+
+var _genesys = {
+    onReady: [],
+    chat: {
+        registration: false,
+        localization : 'https://chat-proxy.hel.fi/gms/sote/localization/chat-testisivu-fi.json',
+        onReady: [],
+        ui: {
+            onBeforeChat: function (chat) {
+                _genesys.chat.onReady.push(function (chatWidgetApi) {
+                    chatWidgetApi.restoreChat({
+                        serverUrl: "https://chat-proxy.hel.fi/chat/sote/cobrowse",
+                        registration: function (done) {
+                            done({
+                                 service: 'TESTISIVU_TESTI'
+                            });
+                        }
+                    }).done(function (session) {
+                        session.setUserData({
+                           service: 'TESTISIVU_TESTI'
+                        });
+                    }).fail(function (par) {
+                        alert(par.description);
+                    });
+                });
+            }
+        }
+    }
+};
+_genesys.cobrowse = false;
+
+
+var url = window.location.search;
+url = decodeURIComponent(url);
+var referringURL = '';
+var returnURL = '';
+
+/* FILL HERE DRUPAL URL SCOPE UNDER WHICH SUUNTE CHAT IS RUN, COOKIE WOULD BE GOOD TO HAVE URL CONTEXT AS WELL IF MULTIPLE GENESYS CHATS ARE RUN UNDER SAME DOMAIN */
+var helfiChatCookiePath = '/fi/sosiaali-ja-terveyspalvelut/';
+
+// show authenticate button 0 no, 1 yes:
+var int_gcLoginButtonState=0;
+
+// dir = out => transfer to authentication
+if(url.indexOf('?dir=out') !== -1){
+  referringURL = document.referrer;
+  //setting helper cookie return url:
+  document.cookie = "gcReturnUrl="+referringURL+";path="+helfiChatCookiePath;
+  callShibboleth();
+}
+
+// dir = in => transfer to back to hel.fi -site from authentication
+if(url.indexOf('?dir=in') !== -1){
+  // set gcLoginButtonState -info cookie, if user has authenticated=1, or not..
+    var now = new Date();
+    var time = now.getTime();
+   int_gcLoginButtonState=1;
+    time += 180 * 1000;
+    now.setTime(time);
+   document.cookie = "gcLoginButtonState="+int_gcLoginButtonState +"; expires=" + now.toUTCString() +";path="+helfiChatCookiePath;
+
+  // get return url back from hel.fi cookie:
+  returnURL = getCookieChat("gcReturnUrl");
+
+  // redirect urser back from Vetuma, to hel.fi -site:
+  // prevent endless loop, do not redirect back to this transfer page itself!
+  if(returnURL!="" && returnURL.indexOf('transfer') == -1 && !isEmpty(returnURL) && !isBlank(returnURL)){
+     window.location.href = returnURL + '?redir=done';
+  }
+  else{
+    // search alternative returnURl cookie, set by hel.fi chat page before user clicked authenticate link:
+     returnURL = getCookieChat("gcAlternativeReturnUrl");
+       if(returnURL!="" && returnURL.indexOf('transfer') == -1 && !isEmpty(returnURL) && !isBlank(returnURL)){
+          window.location.href = returnURL + '?redir2=done';
+      }
+    // default fallback: some error happened. Redirect back to top level contextual main page:
+     window.location = helfiChatCookiePath + '?redir3=done';
+  }
+}

--- a/public/modules/custom/helfi_sote/assets/js/genesys_suunte_test_old.js
+++ b/public/modules/custom/helfi_sote/assets/js/genesys_suunte_test_old.js
@@ -1,0 +1,440 @@
+var helfiChatCookiePath = '/fi/sosiaali-ja-terveyspalvelut/';
+var helfiChatTransferPath = helfiChatCookiePath + 'genesys-auth-redirect-test-old?dir=out';
+var gcReturnSessionId = '';
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.removeChatIcon = function() {
+    $(".cx-window-manager").css("display", "none");
+  }
+
+  Drupal.setGcReturnSessionId = function() {
+    // helper cookie to maintain chat session id:
+    var gcReturnSessionId = Drupal.getCookieChat("_genesys.widgets.webchat.state.session");
+    if (!Drupal.isEmpty(gcReturnSessionId) && !Drupal.isBlank(gcReturnSessionId)) {
+      // Found GS-chat session, setting it to helper cookie:
+      /* document.cookie = "gcReturnSessionId="+gcReturnSessionId+";path=/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/"; */
+      document.cookie =
+        "gcReturnSessionId=" + gcReturnSessionId + ";path=" + helfiChatCookiePath;
+    } else {
+      //console.log("gcReturnSessionId", gcReturnSessionId);
+      alert(
+        "Virhe, ei voida tunnistaa käyttäjää, koska chat-keskustelu ei ole auki."
+      );
+      return false;
+    }
+    // save alternative return url for cookie:
+    document.cookie =
+      "gcAlternativeReturnUrl=" +
+      window.location.href +
+      ";path=" +
+      helfiChatCookiePath;
+    return true;
+  }
+
+  Drupal.getCookieChat = function(cname) {
+    var name = cname + "=";
+    var ca = document.cookie.split(";");
+    for (var i = 0; i < ca.length; i++) {
+      var c = ca[i];
+      while (c.charAt(0) == " ") {
+        c = c.substring(1);
+      }
+      if (c.indexOf(name) == 0) {
+        return c.substring(name.length, c.length);
+      }
+    }
+    return "";
+  }
+
+  Drupal.isEmpty = function(str) {
+        return !str || 0 === str.length;
+  }
+
+  Drupal.isBlank = function(str) {
+    return !str || /^\s*$/.test(str);
+  }
+
+  Drupal.behaviors.genesys_suunte = {
+    attach: function (context, settings) {
+      var helFiChatPageUrl = document.location.href;
+      helFiChatPageUrl = helFiChatPageUrl.toLowerCase();
+      var helfiChat_lang = document.documentElement.lang;
+
+      var accesabilityTexts = {
+        fi: {
+          userIconAlt: "käyttäjä",
+          agentIconAlt: "agentti",
+        },
+        en: {
+          userIconAlt: "user",
+          agentIconAlt: "agent",
+        },
+        sv: {
+          userIconAlt: "användare",
+          agentIconAlt: "ombud",
+        },
+      };
+
+      var startChatButtonClasses = {
+        desktop: {
+          fi: {
+            open: "cx-webchat-chat-button-open",
+            busy: "cx-webchat-chat-button-busy",
+            close: "cx-webchat-chat-button-closed",
+          },
+          sv: {
+            open: "cx-webchat-chat-button-open-sv",
+            busy: "cx-webchat-chat-button-busy-sv",
+            close: "cx-webchat-chat-button-closed-sv",
+          },
+          en: {
+            open: "cx-webchat-chat-button-open-en",
+            busy: "cx-webchat-chat-button-busy-en",
+            close: "cx-webchat-chat-button-closed-en",
+          },
+        },
+        mobile: {
+          fi: {
+            open: "cx-webchat-chat-button-mobile-open",
+            busy: "cx-webchat-chat-button-mobile-busy",
+            close: "cx-webchat-chat-button-mobile-closed",
+          },
+          sv: {
+            open: "cx-webchat-chat-button-mobile-open-sv",
+            busy: "cx-webchat-chat-button-mobile-busy-sv",
+            close: "cx-webchat-chat-button-mobile-closed-sv",
+          },
+          en: {
+            open: "cx-webchat-chat-button-mobile-open",
+            busy: "cx-webchat-chat-button-mobile-busy",
+            close: "cx-webchat-chat-button-mobile-closed",
+          },
+        },
+      };
+
+      var authEnabled = true;
+      var helfiChatLogoElement =
+        '<img class="gwc-chat-logo-helsinki" tabindex="0" title="helsinki-logo" alt="helsinki-logo" src="https://www.hel.fi/static/helsinki/chat/project-logo-hki-white-fi.png"/>';
+
+      var mobileIksButton =
+        '<div id="gwc-chat-icon-iks-mobile"' +
+        'tabindex="0" onkeypress="onEnter(event, this)" role="button" onclick="Drupal.removeChatIcon()"><img src="https://www.hel.fi/static/helsinki/chat/close-next.svg" /><div></div></div';
+      var helFiChat_SendButton = '<img class = "hki-cx-send-icon" src="https://www.hel.fi/static/helsinki/chat/arrow_black.svg" />';
+      var helFiChat_AgentIcon = '<img class = "hki-cx-avatar-icon" src="https://www.hel.fi/static/helsinki/chat/agent_blue.svg" alt="${accesabilityTexts[helfiChat_lang].agentIconAlt}" />';
+      var helFiChat_UserIcon = '<img class="hki-cx-avatar-icon" src="https://www.hel.fi/static/helsinki/chat/user_black.svg" alt="${accesabilityTexts[helfiChat_lang].userIconAlt}" />';
+
+      /* CHAT START BUTTON ICONS */
+      var helFiChat_button = "";
+      var helFiChat_localization =
+        "https://chat-proxy.hel.fi/gms/sote/localization/chat-testisivu-fi.json";
+      var helFiChat_service = "TESTISIVU_TESTI"; //SUUNTE
+      var helFiChat_language = "fi";
+      var helfiChat_GUI_lang = helFiChat_language;
+      var helFiChat_title = "Hammashoidon chat";
+
+	    /* FILL BELOW LINE CORRECT PATH WHERE CALLSHIBBOLETH FUNCTION IS RUN OR FUNCTION ITSELF?: */
+      var helfiChatAuthElement = '<div id="chatAuthenticationElement"><a href="javascript:void(0);" title="" target="" onclick="var testReturnSessionId=Drupal.setGcReturnSessionId();if(testReturnSessionId){window.location=helfiChatTransferPath;}" href="javascript:void(0);">Tunnistaudu tästä</a></div>';
+      var helfiChatAuthElementDone = '<div id="authUserTitleContainer" style="display: none;">Tunnistautunut käyttäjä</div>';
+
+
+      function callShibboleth() {
+        var interactionId = readInteractionIDFromCookie(
+          "_genesys.widgets.webchat.state.session"
+        );
+        var currentPage = window.location;
+        var shibbolethString =
+          "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+        shibbolethString += "target=";
+        shibbolethString +=
+          "https://asiointi.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+        /*
+              shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+              */
+        shibbolethString +=
+          "%3ForigPage%3Dhttps://www.hel.fi" +
+          helfiChatTransferPath +
+          "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
+        shibbolethString += "%26interactionId%3D" + interactionId;
+        window.location = shibbolethString;
+      }
+
+      function initHelFiChatAuthButtonState() {
+        // State of Vetuma authentication result:
+        gcReturnSessionId = Drupal.getCookieChat("gcSession");
+        // is user authenticated, 1=yes
+        var chatGcLoginButtonState = Drupal.getCookieChat("gcLoginButtonState");
+        //is genesys original session active now?
+        var gcOriginalSessionID = "";
+        gcOriginalSessionID = Drupal.getCookieChat("_genesys.widgets.webchat.state.session");
+        if (gcOriginalSessionID) {
+          setTimeout(function () {
+            // if(chatGcLoginButtonState==1) {
+            if (
+              chatGcLoginButtonState == 1 &&
+              document.getElementById("chatAuthenticationElement")
+            ) {
+              //user is authenticated, show correct link in chat window:
+              document.getElementById("chatAuthenticationElement").style.display =
+                "none";
+              document.getElementById("authUserTitleContainer").style.display = "";
+              document.getElementById("authUserTitleContainer").style.display =
+                "flex";
+            }
+            // else {
+            else if (document.getElementById("chatAuthenticationElement")) {
+              //user is not authenticated, show correct link in chat window:
+              document.getElementById("chatAuthenticationElement").style.display = "";
+              document.getElementById("chatAuthenticationElement").style.display =
+                "flex";
+              document.getElementById("authUserTitleContainer").style.display =
+                "none";
+            }
+          }, 2000); /* setTimeout */
+        }
+      } /* ...end function initHelFiChatAuthButtonState() */
+
+      window.addEventListener("load", initHelFiChatAuthButtonState);
+
+      // ------- Auth functions starts ------------
+
+      // ------- Auth functions ends ------------
+
+      function isMobile() {
+        if (screen.width < 600) {
+          return true;
+        }
+        return false;
+      }
+
+      (function setChatStartButton() {
+        //Check if it's mobile
+        var screenType = isMobile() ? "mobile" : "desktop";
+
+        helFiChat_button = "";
+        if (helFiChat_button.indexOf("chat-closed") > -1) {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].close;
+        } else if (helFiChat_button.indexOf("chat-busy") > -1) {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].busy;
+        } else {
+          helFiChat_button = startChatButtonClasses[screenType][helfiChat_lang].open;
+        }
+      })();
+
+      function generateStartChatButton() {
+        // var screenType = isMobile();
+        // // var mobileIksButton = '<div id="gwc-chat-icon-iks-mobile"' +
+        // //             'tabindex="0" onkeypress="onEnter(event, this)" role="button" onclick="removeChatIcon()"><img src="https://www.hel.fi/static/helsinki/chat/close-next.svg" /></div>'
+
+        var buttonHtml =
+          '<div class="cx-widget cx-webchat-chat-button ' +
+          helFiChat_button +
+          ' cx-side-button" id="chatButtonStart" role="button" tabindex="0" data-message="ChatButton"' +
+          'data-gcb-service-node="true"><span class="cx-icon" data-icon="chat"></span><span class="i18n cx-chat-button-label" data-message="ChatButton"></span></div>';
+        return buttonHtml;
+      }
+
+      if (!window._genesys) { window._genesys = {};
+      }
+      if (!window._gt) { window._gt = [];
+      }
+
+      window._genesys.widgets = {
+        main: {
+          theme: "helsinki-blue",
+          themes: {
+            "helsinki-blue": "cx-theme-helsinki-blue",
+          },
+          mobileMode: "auto",
+          lang: helfiChat_lang,
+          i18n: helFiChat_localization,
+          mobileModeBreakpoint: 600,
+          preload: ["webchat"],
+        },
+        webchat: {
+          dataURL: "https://chat-proxy.hel.fi/gms/sote/genesys/2/chat/prod",
+          confirmFormCloseEnabled: false,
+          userData: {
+            service: helFiChat_service,
+          },
+          timeFormat: 24,
+          cometD: {
+            enabled: false,
+          },
+          autoInvite: {
+            enabled: false,
+            timeToInviteSeconds: 10,
+            inviteTimeoutSeconds: 30,
+          },
+          chatButton: {
+            enabled: true,
+            template: generateStartChatButton(),
+            effect: "fade",
+            openDelay: 1000,
+            effectDuration: 300,
+            hideDuringInvite: true,
+          },
+          uploadEnabled: false,
+        },
+      };
+
+      if (!window._genesys.widgets.extensions) {
+        window._genesys.widgets.extensions = {};
+      }
+      var chatExtension = null;
+      chatExtension = CXBus.registerPlugin("ChatExt");
+
+      window._genesys.widgets.extensions["ChatExt"] = function ($, CXBus, Common) {
+        chatExtension.before("WebChat.open", function (oData) {
+          //Delete X button in mobile view
+          //console.log("restarted from open");
+          $("#gwc-chat-icon-iks-mobile").css("display", "none");
+
+          if (!oData.restoring) {
+            oData = {
+              form: {
+                autoSubmit: true,
+                nickname: "Asiakas",
+              },
+              formJSON: {
+                //wrapper: '<table style="display:none;"></table>',
+                inputs: [
+                  {
+                    id: "cx_webchat_form_nickname",
+                    name: "nickname",
+                    maxlength: "100",
+                    value: "Asiakas",
+                    type: "hidden",
+                  },
+                ],
+              },
+              userData: {
+                service: helFiChat_service,
+              },
+            };
+          }
+
+          //console.log(oData);
+          return oData;
+        });
+
+        //Triggers when chat is opened
+        chatExtension.subscribe("WebChat.opened", function (e) {
+          //Add auth layout
+          if (authEnabled) {
+            $(".cx-body").prepend(helfiChatAuthElement);
+            $(".cx-body").prepend(helfiChatAuthElementDone);
+          }
+
+          //Add logo
+          $(".cx-titlebar .cx-icon").replaceWith(helfiChatLogoElement);
+
+          $(".cx-input-container").removeAttr("tabindex").removeAttr("aria-hidden");
+          $(".cx-textarea-cell").removeAttr("tabindex").removeAttr("aria-hidden");
+          $(".cx-send").attr("tabindex", 0);
+          $(".cx-send").removeAttr("aria-hidden");
+
+          //Delete X button in mobile view
+          $("#gwc-chat-icon-iks-mobile").css("display", "none");
+          setTimeout(function () {
+            $("#gwc-chat-icon-iks-mobile").css("display", "none");
+          }, 500);
+
+          //Add accesability enchanced features on minimize
+          if ($("[data-icon=minimize]").length) {
+            $("[data-icon=minimize]").attr("aria-expanded", true);
+          }
+
+          //Change send icon
+          if ($(".cx-send").length) {
+            $(".cx-send").empty().append(helFiChat_SendButton);
+          }
+
+          //Change user icon
+          handleChangeAvatarIcons();
+
+          if ($(".cx-message-input.cx-input").length) {
+            $(".cx-message-input.cx-input").attr("tabindex", 0);
+          }
+        });
+
+        function minimizeAccesibilityChange(name) {
+          //Minimizdd button accesibility change
+          var minimizeElement = $(".cx-button-" + name);
+          if (minimizeElement) {
+            var ariaExpanded = JSON.parse(minimizeElement.attr("aria-expanded"));
+            minimizeElement.attr("aria-expanded", !ariaExpanded);
+          }
+        }
+
+        //Triggers when chat is ready to accept commands
+        chatExtension.subscribe("WebChat.ready", function (e) {
+          if (isMobile()) {
+            setTimeout(function () {
+              //showButton(true);
+              if ($(".cx-webchat-chat-button").length) {
+                $(".cx-side-button-group").prepend(mobileIksButton);
+              }
+            }, 3000);
+          }
+        });
+
+        // Remove custom visibility logic and show button upon closing chat
+        chatExtension.subscribe("WebChat.closed", function (e) {
+          if (isMobile()) {
+            setTimeout(function () {
+              if ($(".cx-webchat-chat-button").length) {
+                $(".cx-side-button-group").prepend(mobileIksButton);
+              }
+            }, 3000);
+          }
+        });
+
+        chatExtension.subscribe("WebChat.cancelled", function (e) {
+          // cancelled event. The Chat session ended before agent is connected to WebChat.
+          setTimeout(function () {
+            chatExtension
+              .command("WebChat.close")
+              .done(function (e) {
+                // closing success
+              })
+              .fail(function (e) {
+                // closing failure
+              });
+          }, 1000);
+        });
+
+        chatExtension.subscribe("WebChat.minimized", function (e) {
+          minimizeAccesibilityChange("maximize");
+        });
+
+        chatExtension.subscribe("WebChat.unminimized", function (e) {
+          minimizeAccesibilityChange("minimize");
+        });
+
+        chatExtension.subscribe("WebChat.messageAdded", function (event) {
+          handleChangeAvatarIcons();
+        });
+
+        function handleChangeAvatarIcons() {
+          //Change user icon
+          if ($(".cx-avatar.user").length) {
+            $(".cx-avatar.user").empty().append(helFiChat_UserIcon);
+          }
+
+          //Change agent icons
+          if ($(".cx-avatar.agent").length) {
+            $(".cx-avatar.agent").empty().append(helFiChat_AgentIcon);
+          }
+        }
+
+        chatExtension.republish("ready");
+        chatExtension.ready();
+        window.chatExtension = chatExtension;
+
+      };
+    }
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/public/modules/custom/helfi_sote/helfi_sote.libraries.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.libraries.yml
@@ -38,3 +38,44 @@ genesys_auth_redirect_test:
     - core/jquery
     - core/drupal
     - core/drupalSettings
+
+genesys_suunte_test_old:
+  version: 1.0.0
+  header: true
+  js:
+    'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
+      type: external,
+      minified: true,
+      attributes: {
+        onload: "javascript:CXBus.configure({pluginsPath:'https://apps.mypurecloud.ie/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
+      }
+    }
+    assets/js/genesys_suunte_test_old.js: {
+      attributes: {
+        onload: "javascript:var checkExist = setInterval(function() {if(typeof CXBus != 'undefined') {clearInterval(checkExist);Drupal.behaviors.genesys_suunte.attach();console.log('suunte test attaching');}}, 100);"
+      }
+    }
+  css:
+    theme:
+      assets/css/genesys_chat.css: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+
+genesys_auth_redirect_test_old:
+  version: 1.0.0
+  header: true
+  js:
+    'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
+      type: external,
+      minified: true,
+      attributes: {
+        onload: "javascript:CXBus.configure({pluginsPath:'https://apps.mypurecloud.ie/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
+      }
+    }
+    assets/js/genesys_auth_redirect_test_old.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings

--- a/public/modules/custom/helfi_sote/helfi_sote.routing.yml
+++ b/public/modules/custom/helfi_sote/helfi_sote.routing.yml
@@ -5,3 +5,11 @@ helfi_sote.genesys_auth_redirect_test:
     _title: 'Genesys auth redirect test'
   requirements:
     _permission: 'access content'
+
+helfi_sote.genesys_auth_redirect_test_old:
+  path: '/genesys-auth-redirect-test-old'
+  defaults:
+    _controller: '\Drupal\helfi_sote\Controller\GenesysAuthRedirectControllerTestingOld::content'
+    _title: 'Genesys old auth redirect test'
+  requirements:
+    _permission: 'access content'

--- a/public/modules/custom/helfi_sote/src/Controller/GenesysAuthRedirectControllerTestingOld.php
+++ b/public/modules/custom/helfi_sote/src/Controller/GenesysAuthRedirectControllerTestingOld.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\helfi_sote\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Genesys auth redirect controller.
+ */
+class GenesysAuthRedirectControllerTestingOld extends ControllerBase {
+
+  /**
+   * Returns a renderable array with attached JavaScript.
+   */
+  public function content() {
+    $build = [
+      '#markup' => $this->t('Redirecting...'),
+      '#attached' => [
+        'library' => ['helfi_sote/genesys_auth_redirect_test_old'],
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/public/modules/custom/helfi_sote/src/Plugin/Block/SuunteTest.php
+++ b/public/modules/custom/helfi_sote/src/Plugin/Block/SuunteTest.php
@@ -31,6 +31,7 @@ class SuunteTest extends BlockBase {
       '#default_value' => $config['chat_selection'] ?? '',
       '#options' => [
         'genesys_suunte_test' => 'Genesys SUUNTE TEST',
+        'genesys_suunte_test_old' => 'Genesys SUUNTE TEST OLD',
       ],
     ];
 


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* TietoEvry needs a test chat with old authentication URL domain for fixing the authentication with the new domains.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_Add-old-chat-auth-url-test`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add SUUNTE TEST -block to some page and choose the 'Genesys SUUNTE TEST OLD' for the chat.
* [x] Check that the chat works and clickin "Tunnistaudu tästä" link takes to the authentication page succesfully.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
