### PR TITLE
UHF-X Add correct result title and empty text for fallback listings on SOTE instance

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--health-station-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--health-station-search.html.twig
@@ -56,14 +56,17 @@
   {{ attachment_before }}
 
   <div class="unit-search__results" data-id-number="{{ dom_id }}">
-    <span class="unit-search__count-container">
-      {% if total_rows %}
-        <span class="unit-search__count">{{ total_rows }}</span>
-        {% trans with {'context': 'Health station search count'}%}health station{% plural total_rows %}health stations{% endtrans %}
-      {% endif %}
+    <h3 class="unit-search__count-container">
+      {%- if total_rows -%}
+        {{ total_rows }} {% trans with {'context': 'Health station search count'}%}health station{% plural total_rows %}health stations{% endtrans %}
+      {%- else -%}
+        {{ 'No results'|t({}, {'context' : 'Unit search no results title'}) }}
+      {%- endif -%}
+    </h3>
 
-      {{ empty }}
-    </span>
+    {%- if empty -%}
+      <p>{{ 'No results were found for the criteria you entered. Try changing your search criteria.'|t({}, {'context' : 'Unit search no results text'}) }}</p>
+    {%- endif -%}
 
     {{ rows }}
 

--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--maternity-and-child-health-clinics-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--maternity-and-child-health-clinics-search.html.twig
@@ -56,14 +56,17 @@
   {{ attachment_before }}
 
   <div class="unit-search__results" data-id-number="{{ dom_id }}">
-    <span class="unit-search__count-container">
-      {% if total_rows %}
-        <span class="unit-search__count">{{ total_rows }}</span>
-        {% trans with {'context': 'Maternity and child health clinics search count'}%}clinic{% plural total_rows %}clinics{% endtrans %}
-      {% endif %}
+    <h3 class="unit-search__count-container">
+      {%- if total_rows -%}
+        {{ total_rows }} {% trans with {'context': 'Maternity and child health clinics search count'}%}clinic{% plural total_rows %}clinics{% endtrans %}
+      {%- else -%}
+        {{ 'No results'|t({}, {'context' : 'Unit search no results title'}) }}
+      {%- endif -%}
+    </h3>
 
-      {{ empty }}
-    </span>
+    {%- if empty -%}
+      <p>{{ 'No results were found for the criteria you entered. Try changing your search criteria.'|t({}, {'context' : 'Unit search no results text'}) }}</p>
+    {%- endif -%}
 
     {{ rows }}
 


### PR DESCRIPTION
# UHF-X

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_title_empty_text_fix_for_fallbacks`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the health station and maternity clinic fallback searches also have the correct search result title (h3) and unified empty text.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

