### PR TITLE
UHF-9327: Unified number of search results for the filter searches 

### DIFF
--- a/conf/cmi/views.view.health_station_search.yml
+++ b/conf/cmi/views.view.health_station_search.yml
@@ -417,7 +417,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 10
+          items_per_page: 15
           total_pages: null
           id: 0
           tags:

--- a/conf/cmi/views.view.maternity_and_child_health_clinics_search.yml
+++ b/conf/cmi/views.view.maternity_and_child_health_clinics_search.yml
@@ -12,7 +12,7 @@ dependencies:
 id: maternity_and_child_health_clinics_search
 label: 'Maternity and child health clinics search'
 module: views
-description: 'Fallback listing for the health station search'
+description: 'Fallback listing for the maternity and child health clinic search'
 tag: ''
 base_table: tpr_unit_field_data
 base_field: id
@@ -417,7 +417,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 10
+          items_per_page: 15
           total_pages: null
           id: 0
           tags:


### PR DESCRIPTION
# [UHF-9327](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9327)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the number of items per page to 15 in health station search fallback and maternity and child health clinic search fallback.

## How to install
* Check installation instructions from the [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/900)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the  [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/900)
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

*  https://github.com/City-of-Helsinki/drupal-hdbt/pull/900
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/684
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/791
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/563
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/755


[UHF-9327]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ