### PR TITLE
UHF-X: Remove ELASTIC_PROXY_URL preflight check

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -56,7 +56,9 @@ $additionalEnvVars = [
   'SENTRY_DSN',
   'SENTRY_ENVIRONMENT',
   // Project specific variables.
-  'ELASTIC_PROXY_URL',
+  // @fixme removed elastic proxy url for now since this is misconfigured on
+  // staging and production environments.
+  // 'ELASTIC_PROXY_URL',
   'ELASTICSEARCH_URL',
   'ELASTIC_USER',
   'ELASTIC_PASSWORD',


### PR DESCRIPTION
`ELASTIC_PROXY_UR` url is misconfigured on staging and production environments. Temporarily remove this check so that deployments can proceed.