### PR TITLE
Revert "UHF-X: Remove ELASTIC_PROXY_URL preflight check"

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -56,9 +56,7 @@ $additionalEnvVars = [
   'SENTRY_DSN',
   'SENTRY_ENVIRONMENT',
   // Project specific variables.
-  // @fixme removed elastic proxy url for now since this is misconfigured on
-  // staging and production environments.
-  // 'ELASTIC_PROXY_URL',
+  'ELASTIC_PROXY_URL',
   'ELASTICSEARCH_URL',
   'ELASTIC_USER',
   'ELASTIC_PASSWORD',


### PR DESCRIPTION
# [PSD-2240](https://helsinkisolutionoffice.atlassian.net/servicedesk/customer/portal/3/PSD-2240)

Elasticsearch configuration is now fixed. Reverts City-of-Helsinki/drupal-helfi-sote#805.


[PSD-2240]: https://helsinkisolutionoffice.atlassian.net/browse/PSD-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ