### PR TITLE
UHF-10102: Update ELASTIC_PROXY_URL variable to point to nginx proxy.

### DIFF
--- a/.env
+++ b/.env
@@ -24,4 +24,4 @@ DRUPAL_IMAGE=ghcr.io/city-of-helsinki/drupal-web:8.3
 DRUPAL_WEBROOT=public
 
 # Elastic url
-ELASTIC_PROXY_URL=https://elastic-helfi-sote.docker.so
+ELASTIC_PROXY_URL=https://elastic-proxy-helfi-sote.docker.so


### PR DESCRIPTION
# [UHF-10102](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102)

## What was done
* Changes local ELASTIC_PROXY_URL environment variable to use nginx proxy instead of the local elasticsearch service.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10102-change-elastic-proxy-url`
  * `make up` (to make sure the new environment variable updates)
  * `make fresh`
* Install the correct HDBT branch: `composer require drupal/hdbt:dev-UHF-10102-support-elastic-nginx-proxy`
* Run `make drush-cr`
* Reindex all content: `drush sapi-c;drush sapi-rt;drush sapi-i`

## How to test
* Check that the nginx proxy URLs works:
  * [ ] https://elastic-proxy-helfi-sote.docker.so/health_stations/_search
  * [ ] https://elastic-proxy-helfi-sote.docker.so/maternity_and_child_health_clinic/_search
* [ ] Check that this feature works: https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/suunnitelmat-ja-rakennushankkeet and https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/lasten-ja-perheiden-palvelut/aitiys-ja-lastenneuvolat
  * [ ] Test with multiple filter and query combinations 
  * [ ] Check that the search app works on other languages too
* [ ] Check that code follows our standards

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1007
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/652
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/499
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/889
* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/425

[UHF-10102]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ