### PR TITLE
UHF-10647: Removing helfi_recommendations from enabled modules

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -84,7 +84,6 @@ module:
   helfi_platform_config_base: 0
   helfi_proxy: 0
   helfi_react_search: 0
-  helfi_recommendations: 0
   helfi_sote: 0
   helfi_sote_config: 0
   helfi_tfa: 0


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

We will only enable it in etusivu for now, and then on rest of the core instances later when we have the required routes to write into etusivu elasticsearch from other core instances.
